### PR TITLE
docs: clean up documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vuquest-3320"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Vuquest 3320 developers", "Decapod ATM developers"]
 description = "Serial communication protocol for Honeywell BCS devices"

--- a/src/command/image_snap.rs
+++ b/src/command/image_snap.rs
@@ -1,3 +1,5 @@
+//! Types and algorithms related to `Image Snap` configuration.
+
 use alloc::string::{String, ToString};
 
 use crate::result::{Error, Result};
@@ -63,6 +65,17 @@ macro_rules! image_snap_field {
         }
     };
 }
+
+image_snap_field!(imaging_style: ImagingStyle);
+image_snap_field!(beeper: Beeper);
+image_snap_field!(wait_for_trigger: WaitForTrigger);
+image_snap_field!(led: LED);
+image_snap_field!(exposure: Exposure);
+image_snap_field!(gain: Gain);
+image_snap_field!(target_white_value: TargetWhiteValue);
+image_snap_field!(delta_for_acceptance: DeltaForAcceptance);
+image_snap_field!(update_tries: UpdateTries);
+image_snap_field!(target_set_point: TargetSetPoint);
 
 impl ImageSnap {
     /// Creates a new [ImageSnap].
@@ -296,17 +309,6 @@ impl ImageSnap {
         format!("{IMAGE_SNAP}{imaging}{beeper}{wait_for_trigger}{led}{exposure}{gain}{twv}{delta}{update}{tsp}")
     }
 }
-
-image_snap_field!(imaging_style: ImagingStyle);
-image_snap_field!(beeper: Beeper);
-image_snap_field!(wait_for_trigger: WaitForTrigger);
-image_snap_field!(led: LED);
-image_snap_field!(exposure: Exposure);
-image_snap_field!(gain: Gain);
-image_snap_field!(target_white_value: TargetWhiteValue);
-image_snap_field!(delta_for_acceptance: DeltaForAcceptance);
-image_snap_field!(update_tries: UpdateTries);
-image_snap_field!(target_set_point: TargetSetPoint);
 
 impl Default for ImageSnap {
     fn default() -> Self {

--- a/src/command/manual_trigger.rs
+++ b/src/command/manual_trigger.rs
@@ -3,7 +3,7 @@ use crate::result::{Error, Result};
 const NORMAL: &str = "PAPHHF";
 const ENHANCED: &str = "PAPHHS";
 
-/// Represents the `Mobile Phone Read Mode` serial command.
+/// Represents the `Manual Trigger Mode` serial command.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum ManualTriggerMode {
     Normal,

--- a/src/command/pdf.rs
+++ b/src/command/pdf.rs
@@ -4,7 +4,7 @@ const DEFAULT_SETTINGS: &str = "PDFDFT";
 const PDF_OFF: &str = "PDFENA0";
 const PDF_ON: &str = "PDFENA1";
 
-/// Represents the `Mobile Phone Read Mode` serial command.
+/// Represents the `PDF417` serial command.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum PDF417 {
     DefaultSettings,

--- a/src/command/qr.rs
+++ b/src/command/qr.rs
@@ -4,7 +4,7 @@ const DEFAULT_SETTINGS: &str = "QRCDFT";
 const QR_OFF: &str = "QRCENA0";
 const QR_ON: &str = "QRCENA1";
 
-/// Represents the `Mobile Phone Read Mode` serial command.
+/// Represents the `QR Code` serial command.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum QRCode {
     DefaultSettings,

--- a/src/command/serial_trigger.rs
+++ b/src/command/serial_trigger.rs
@@ -6,7 +6,7 @@ const SERIAL_TRIGGER: &str = "TRGSTO";
 /// Maximum timeout (in milliseconds) for [SerialTriggerMode].
 pub const MAX_SERIAL_TRIGGER: u32 = 300_000;
 
-/// Represents the `Mobile Phone Read Mode` serial command.
+/// Represents the `Serial Trigger Mode` serial command.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SerialTriggerMode {
     ms: u32,

--- a/src/command/trigger.rs
+++ b/src/command/trigger.rs
@@ -5,7 +5,7 @@ const TRIGGER_ACTIVATE: &str = "\x16T\x0d";
 // <SYN>U<CR>
 const TRIGGER_DEACTIVATE: &str = "\x16U\x0d";
 
-/// Represents the `Mobile Phone Read Mode` serial command.
+/// Represents the `Trigger Activation` serial command.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub enum Trigger {
     Activate,

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,6 +1,8 @@
+//! Result and error types for the library.
+
 use core::fmt;
 
-/// Convenience alias for the library [Result](std::result::Result) type.
+/// Convenience alias for the library [Result](core::result::Result) type.
 pub type Result<T> = core::result::Result<T, Error>;
 
 /// Represents error conditions for the library.


### PR DESCRIPTION
Fixes typos in library documentation, and adds missing module documentation.

Bumps the patch release to `v0.1.1` for documentation fixes.