### PR TITLE
command: add image ship implementation

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -4,6 +4,7 @@ use core::fmt;
 
 use alloc::string::String;
 
+pub mod image_ship;
 pub mod image_snap;
 mod manual_trigger;
 mod mobile_phone;
@@ -15,7 +16,8 @@ mod software_rev;
 mod symbologies;
 mod trigger;
 
-pub use image_snap::*;
+pub use image_ship::ImageShip;
+pub use image_snap::ImageSnap;
 pub use manual_trigger::*;
 pub use mobile_phone::*;
 pub use pdf::*;
@@ -31,6 +33,7 @@ pub use trigger::*;
 pub enum SerialCommand {
     AllSymbologies(AllSymbologies),
     ImageSnap(ImageSnap),
+    ImageShip(ImageShip),
     ManualTriggerMode(ManualTriggerMode),
     MobilePhoneReadMode(MobilePhoneReadMode),
     PDF417(PDF417),
@@ -50,6 +53,7 @@ impl SerialCommand {
         match self {
             Self::AllSymbologies(cmd) => cmd.command().into(),
             Self::ImageSnap(cmd) => cmd.command(),
+            Self::ImageShip(cmd) => cmd.command(),
             Self::ManualTriggerMode(cmd) => cmd.command().into(),
             Self::MobilePhoneReadMode(cmd) => cmd.command().into(),
             Self::PDF417(cmd) => cmd.command().into(),

--- a/src/command.rs
+++ b/src/command.rs
@@ -6,6 +6,8 @@ use alloc::string::String;
 
 pub mod image_ship;
 pub mod image_snap;
+#[macro_use]
+mod macros;
 mod manual_trigger;
 mod mobile_phone;
 mod pdf;

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -7,6 +7,7 @@ mod edge_sharpen;
 mod histogram_stretch;
 mod infinity_filter;
 mod invert_image;
+mod noise_reduction;
 mod pixel_depth;
 
 pub use compensation::*;
@@ -14,6 +15,7 @@ pub use edge_sharpen::*;
 pub use histogram_stretch::*;
 pub use infinity_filter::*;
 pub use invert_image::*;
+pub use noise_reduction::*;
 pub use pixel_depth::*;
 
 const IMAGE_SHIP: &str = "IMGSHP";
@@ -27,6 +29,7 @@ pub struct ImageShip {
     edge_sharpen: Option<EdgeSharpen>,
     histogram_stretch: Option<HistogramStretch>,
     invert_image: Option<InvertImage>,
+    noise_reduction: Option<NoiseReduction>,
 }
 
 macro_rules! image_ship_field {
@@ -58,6 +61,7 @@ image_ship_field!(pixel_depth: PixelDepth);
 image_ship_field!(edge_sharpen: EdgeSharpen);
 image_ship_field!(histogram_stretch: HistogramStretch);
 image_ship_field!(invert_image: InvertImage);
+image_ship_field!(noise_reduction: NoiseReduction);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -69,6 +73,7 @@ impl ImageShip {
             edge_sharpen: None,
             histogram_stretch: None,
             invert_image: None,
+            noise_reduction: None,
         }
     }
 
@@ -81,6 +86,7 @@ impl ImageShip {
             edge_sharpen: self.edge_sharpen,
             histogram_stretch: self.histogram_stretch,
             invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
         }
     }
 
@@ -93,6 +99,7 @@ impl ImageShip {
             edge_sharpen: self.edge_sharpen,
             histogram_stretch: self.histogram_stretch,
             invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
         }
     }
 
@@ -105,6 +112,7 @@ impl ImageShip {
             edge_sharpen: self.edge_sharpen,
             histogram_stretch: self.histogram_stretch,
             invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
         }
     }
 
@@ -117,6 +125,7 @@ impl ImageShip {
             edge_sharpen: Some(val),
             histogram_stretch: self.histogram_stretch,
             invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
         }
     }
 
@@ -129,6 +138,7 @@ impl ImageShip {
             edge_sharpen: self.edge_sharpen,
             histogram_stretch: Some(val),
             invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
         }
     }
 
@@ -141,6 +151,20 @@ impl ImageShip {
             edge_sharpen: self.edge_sharpen,
             histogram_stretch: self.histogram_stretch,
             invert_image: Some(val),
+            noise_reduction: self.noise_reduction,
+        }
+    }
+
+    /// Builder function that sets the [NoiseReduction].
+    pub const fn with_noise_reduction(self, val: NoiseReduction) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
+            histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
+            noise_reduction: Some(val),
         }
     }
 
@@ -176,7 +200,12 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
-        format!("{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}")
+        let noise = self
+            .noise_reduction
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
+        format!("{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}")
     }
 }
 
@@ -197,6 +226,7 @@ impl TryFrom<&str> for ImageShip {
         let edge_sharpen = EdgeSharpen::try_from(rem).ok();
         let histogram_stretch = HistogramStretch::try_from(rem).ok();
         let invert_image = InvertImage::try_from(rem).ok();
+        let noise_reduction = NoiseReduction::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
@@ -205,6 +235,7 @@ impl TryFrom<&str> for ImageShip {
             edge_sharpen,
             histogram_stretch,
             invert_image,
+            noise_reduction,
         })
     }
 }
@@ -234,8 +265,9 @@ mod tests {
         let exp_pixel_depth = PixelDepth::new();
         let exp_histogram_stretch = HistogramStretch::new();
         let exp_invert_image = InvertImage::new();
+        let exp_noise_reduction = NoiseReduction::new();
 
-        ["", "0A", "0C", "8D", "0H", "1ix"]
+        ["", "0A", "0C", "8D", "0H", "1ix", "0if"]
             .into_iter()
             .map(|s| format!("{IMAGE_SHIP}{s}"))
             .zip([
@@ -245,6 +277,7 @@ mod tests {
                 ImageShip::new().with_pixel_depth(exp_pixel_depth),
                 ImageShip::new().with_histogram_stretch(exp_histogram_stretch),
                 ImageShip::new().with_invert_image(exp_invert_image),
+                ImageShip::new().with_noise_reduction(exp_noise_reduction),
             ])
             .for_each(|(img_str, exp_img_ship)| {
                 assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
@@ -258,5 +291,6 @@ mod tests {
         test_image_ship_field!(img, pixel_depth, exp_pixel_depth);
         test_image_ship_field!(img, histogram_stretch, exp_histogram_stretch);
         test_image_ship_field!(img, invert_image, exp_invert_image);
+        test_image_ship_field!(img, noise_reduction, exp_noise_reduction);
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -6,12 +6,14 @@ mod compensation;
 mod edge_sharpen;
 mod histogram_stretch;
 mod infinity_filter;
+mod invert_image;
 mod pixel_depth;
 
 pub use compensation::*;
 pub use edge_sharpen::*;
 pub use histogram_stretch::*;
 pub use infinity_filter::*;
+pub use invert_image::*;
 pub use pixel_depth::*;
 
 const IMAGE_SHIP: &str = "IMGSHP";
@@ -24,6 +26,7 @@ pub struct ImageShip {
     pixel_depth: Option<PixelDepth>,
     edge_sharpen: Option<EdgeSharpen>,
     histogram_stretch: Option<HistogramStretch>,
+    invert_image: Option<InvertImage>,
 }
 
 macro_rules! image_ship_field {
@@ -54,6 +57,7 @@ image_ship_field!(compensation: Compensation);
 image_ship_field!(pixel_depth: PixelDepth);
 image_ship_field!(edge_sharpen: EdgeSharpen);
 image_ship_field!(histogram_stretch: HistogramStretch);
+image_ship_field!(invert_image: InvertImage);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -64,6 +68,7 @@ impl ImageShip {
             pixel_depth: None,
             edge_sharpen: None,
             histogram_stretch: None,
+            invert_image: None,
         }
     }
 
@@ -75,6 +80,7 @@ impl ImageShip {
             pixel_depth: self.pixel_depth,
             edge_sharpen: self.edge_sharpen,
             histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
         }
     }
 
@@ -86,6 +92,7 @@ impl ImageShip {
             pixel_depth: self.pixel_depth,
             edge_sharpen: self.edge_sharpen,
             histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
         }
     }
 
@@ -97,6 +104,7 @@ impl ImageShip {
             pixel_depth: Some(val),
             edge_sharpen: self.edge_sharpen,
             histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
         }
     }
 
@@ -108,6 +116,7 @@ impl ImageShip {
             pixel_depth: self.pixel_depth,
             edge_sharpen: Some(val),
             histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
         }
     }
 
@@ -119,6 +128,19 @@ impl ImageShip {
             pixel_depth: self.pixel_depth,
             edge_sharpen: self.edge_sharpen,
             histogram_stretch: Some(val),
+            invert_image: self.invert_image,
+        }
+    }
+
+    /// Builder function that sets the [InvertImage].
+    pub const fn with_invert_image(self, val: InvertImage) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
+            histogram_stretch: self.histogram_stretch,
+            invert_image: Some(val),
         }
     }
 
@@ -149,7 +171,12 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
-        format!("{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}")
+        let invert = self
+            .invert_image
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
+        format!("{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}")
     }
 }
 
@@ -169,6 +196,7 @@ impl TryFrom<&str> for ImageShip {
         let pixel_depth = PixelDepth::try_from(rem).ok();
         let edge_sharpen = EdgeSharpen::try_from(rem).ok();
         let histogram_stretch = HistogramStretch::try_from(rem).ok();
+        let invert_image = InvertImage::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
@@ -176,6 +204,7 @@ impl TryFrom<&str> for ImageShip {
             pixel_depth,
             edge_sharpen,
             histogram_stretch,
+            invert_image,
         })
     }
 }
@@ -204,8 +233,9 @@ mod tests {
         let exp_compensation = Compensation::new();
         let exp_pixel_depth = PixelDepth::new();
         let exp_histogram_stretch = HistogramStretch::new();
+        let exp_invert_image = InvertImage::new();
 
-        ["", "0A", "0C", "8D", "0H"]
+        ["", "0A", "0C", "8D", "0H", "1ix"]
             .into_iter()
             .map(|s| format!("{IMAGE_SHIP}{s}"))
             .zip([
@@ -214,6 +244,7 @@ mod tests {
                 ImageShip::new().with_compensation(exp_compensation),
                 ImageShip::new().with_pixel_depth(exp_pixel_depth),
                 ImageShip::new().with_histogram_stretch(exp_histogram_stretch),
+                ImageShip::new().with_invert_image(exp_invert_image),
             ])
             .for_each(|(img_str, exp_img_ship)| {
                 assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
@@ -226,5 +257,6 @@ mod tests {
         test_image_ship_field!(img, compensation, exp_compensation);
         test_image_ship_field!(img, pixel_depth, exp_pixel_depth);
         test_image_ship_field!(img, histogram_stretch, exp_histogram_stretch);
+        test_image_ship_field!(img, invert_image, exp_invert_image);
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -8,6 +8,7 @@ mod histogram_stretch;
 mod image_rotate;
 mod infinity_filter;
 mod invert_image;
+mod jpeg_image_quality;
 mod noise_reduction;
 mod pixel_depth;
 
@@ -17,6 +18,7 @@ pub use histogram_stretch::*;
 pub use image_rotate::*;
 pub use infinity_filter::*;
 pub use invert_image::*;
+pub use jpeg_image_quality::*;
 pub use noise_reduction::*;
 pub use pixel_depth::*;
 
@@ -33,6 +35,7 @@ pub struct ImageShip {
     invert_image: Option<InvertImage>,
     noise_reduction: Option<NoiseReduction>,
     image_rotate: Option<ImageRotate>,
+    jpeg_image_quality: Option<JpegImageQuality>,
 }
 
 macro_rules! image_ship_field {
@@ -66,6 +69,7 @@ image_ship_field!(histogram_stretch: HistogramStretch);
 image_ship_field!(invert_image: InvertImage);
 image_ship_field!(noise_reduction: NoiseReduction);
 image_ship_field!(image_rotate: ImageRotate);
+image_ship_field!(jpeg_image_quality: JpegImageQuality);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -79,6 +83,7 @@ impl ImageShip {
             invert_image: None,
             noise_reduction: None,
             image_rotate: None,
+            jpeg_image_quality: None,
         }
     }
 
@@ -93,6 +98,7 @@ impl ImageShip {
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
             image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
         }
     }
 
@@ -107,6 +113,7 @@ impl ImageShip {
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
             image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
         }
     }
 
@@ -121,6 +128,7 @@ impl ImageShip {
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
             image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
         }
     }
 
@@ -135,6 +143,7 @@ impl ImageShip {
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
             image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
         }
     }
 
@@ -149,6 +158,7 @@ impl ImageShip {
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
             image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
         }
     }
 
@@ -163,6 +173,7 @@ impl ImageShip {
             invert_image: Some(val),
             noise_reduction: self.noise_reduction,
             image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
         }
     }
 
@@ -177,6 +188,7 @@ impl ImageShip {
             invert_image: self.invert_image,
             noise_reduction: Some(val),
             image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
         }
     }
 
@@ -191,6 +203,22 @@ impl ImageShip {
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
             image_rotate: Some(val),
+            jpeg_image_quality: self.jpeg_image_quality,
+        }
+    }
+
+    /// Builder function that sets the [JpegImageQuality].
+    pub const fn with_jpeg_image_quality(self, val: JpegImageQuality) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
+            histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
+            jpeg_image_quality: Some(val),
         }
     }
 
@@ -236,7 +264,12 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
-        format!("{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}")
+        let jpeg = self
+            .jpeg_image_quality
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
+        format!("{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}")
     }
 }
 
@@ -259,6 +292,7 @@ impl TryFrom<&str> for ImageShip {
         let invert_image = InvertImage::try_from(rem).ok();
         let noise_reduction = NoiseReduction::try_from(rem).ok();
         let image_rotate = ImageRotate::try_from(rem).ok();
+        let jpeg_image_quality = JpegImageQuality::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
@@ -269,6 +303,7 @@ impl TryFrom<&str> for ImageShip {
             invert_image,
             noise_reduction,
             image_rotate,
+            jpeg_image_quality,
         })
     }
 }
@@ -300,6 +335,7 @@ mod tests {
         let exp_invert_image = InvertImage::new();
         let exp_noise_reduction = NoiseReduction::new();
         let exp_image_rotate = ImageRotate::new();
+        let exp_jpeg_image_quality = JpegImageQuality::new();
 
         ["", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir"]
             .into_iter()
@@ -313,6 +349,7 @@ mod tests {
                 ImageShip::new().with_invert_image(exp_invert_image),
                 ImageShip::new().with_noise_reduction(exp_noise_reduction),
                 ImageShip::new().with_image_rotate(exp_image_rotate),
+                ImageShip::new().with_jpeg_image_quality(exp_jpeg_image_quality),
             ])
             .for_each(|(img_str, exp_img_ship)| {
                 assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
@@ -328,5 +365,6 @@ mod tests {
         test_image_ship_field!(img, invert_image, exp_invert_image);
         test_image_ship_field!(img, noise_reduction, exp_noise_reduction);
         test_image_ship_field!(img, image_rotate, exp_image_rotate);
+        test_image_ship_field!(img, jpeg_image_quality, exp_jpeg_image_quality);
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -5,6 +5,7 @@ use crate::result::{Error, Result};
 mod compensation;
 mod edge_sharpen;
 mod histogram_stretch;
+mod image_rotate;
 mod infinity_filter;
 mod invert_image;
 mod noise_reduction;
@@ -13,6 +14,7 @@ mod pixel_depth;
 pub use compensation::*;
 pub use edge_sharpen::*;
 pub use histogram_stretch::*;
+pub use image_rotate::*;
 pub use infinity_filter::*;
 pub use invert_image::*;
 pub use noise_reduction::*;
@@ -30,6 +32,7 @@ pub struct ImageShip {
     histogram_stretch: Option<HistogramStretch>,
     invert_image: Option<InvertImage>,
     noise_reduction: Option<NoiseReduction>,
+    image_rotate: Option<ImageRotate>,
 }
 
 macro_rules! image_ship_field {
@@ -62,6 +65,7 @@ image_ship_field!(edge_sharpen: EdgeSharpen);
 image_ship_field!(histogram_stretch: HistogramStretch);
 image_ship_field!(invert_image: InvertImage);
 image_ship_field!(noise_reduction: NoiseReduction);
+image_ship_field!(image_rotate: ImageRotate);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -74,6 +78,7 @@ impl ImageShip {
             histogram_stretch: None,
             invert_image: None,
             noise_reduction: None,
+            image_rotate: None,
         }
     }
 
@@ -87,6 +92,7 @@ impl ImageShip {
             histogram_stretch: self.histogram_stretch,
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
         }
     }
 
@@ -100,6 +106,7 @@ impl ImageShip {
             histogram_stretch: self.histogram_stretch,
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
         }
     }
 
@@ -113,6 +120,7 @@ impl ImageShip {
             histogram_stretch: self.histogram_stretch,
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
         }
     }
 
@@ -126,6 +134,7 @@ impl ImageShip {
             histogram_stretch: self.histogram_stretch,
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
         }
     }
 
@@ -139,6 +148,7 @@ impl ImageShip {
             histogram_stretch: Some(val),
             invert_image: self.invert_image,
             noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
         }
     }
 
@@ -152,6 +162,7 @@ impl ImageShip {
             histogram_stretch: self.histogram_stretch,
             invert_image: Some(val),
             noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
         }
     }
 
@@ -165,6 +176,21 @@ impl ImageShip {
             histogram_stretch: self.histogram_stretch,
             invert_image: self.invert_image,
             noise_reduction: Some(val),
+            image_rotate: self.image_rotate,
+        }
+    }
+
+    /// Builder function that sets the [ImageRotate].
+    pub const fn with_image_rotate(self, val: ImageRotate) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
+            histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
+            image_rotate: Some(val),
         }
     }
 
@@ -205,7 +231,12 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
-        format!("{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}")
+        let rotate = self
+            .image_rotate
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
+        format!("{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}")
     }
 }
 
@@ -227,6 +258,7 @@ impl TryFrom<&str> for ImageShip {
         let histogram_stretch = HistogramStretch::try_from(rem).ok();
         let invert_image = InvertImage::try_from(rem).ok();
         let noise_reduction = NoiseReduction::try_from(rem).ok();
+        let image_rotate = ImageRotate::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
@@ -236,6 +268,7 @@ impl TryFrom<&str> for ImageShip {
             histogram_stretch,
             invert_image,
             noise_reduction,
+            image_rotate,
         })
     }
 }
@@ -266,8 +299,9 @@ mod tests {
         let exp_histogram_stretch = HistogramStretch::new();
         let exp_invert_image = InvertImage::new();
         let exp_noise_reduction = NoiseReduction::new();
+        let exp_image_rotate = ImageRotate::new();
 
-        ["", "0A", "0C", "8D", "0H", "1ix", "0if"]
+        ["", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir"]
             .into_iter()
             .map(|s| format!("{IMAGE_SHIP}{s}"))
             .zip([
@@ -278,6 +312,7 @@ mod tests {
                 ImageShip::new().with_histogram_stretch(exp_histogram_stretch),
                 ImageShip::new().with_invert_image(exp_invert_image),
                 ImageShip::new().with_noise_reduction(exp_noise_reduction),
+                ImageShip::new().with_image_rotate(exp_image_rotate),
             ])
             .for_each(|(img_str, exp_img_ship)| {
                 assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
@@ -292,5 +327,6 @@ mod tests {
         test_image_ship_field!(img, histogram_stretch, exp_histogram_stretch);
         test_image_ship_field!(img, invert_image, exp_invert_image);
         test_image_ship_field!(img, noise_reduction, exp_noise_reduction);
+        test_image_ship_field!(img, image_rotate, exp_image_rotate);
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -3,10 +3,12 @@ use alloc::string::{String, ToString};
 use crate::result::{Error, Result};
 
 mod compensation;
+mod edge_sharpen;
 mod infinity_filter;
 mod pixel_depth;
 
 pub use compensation::*;
+pub use edge_sharpen::*;
 pub use infinity_filter::*;
 pub use pixel_depth::*;
 
@@ -18,6 +20,7 @@ pub struct ImageShip {
     infinity_filter: Option<InfinityFilter>,
     compensation: Option<Compensation>,
     pixel_depth: Option<PixelDepth>,
+    edge_sharpen: Option<EdgeSharpen>,
 }
 
 macro_rules! image_ship_field {
@@ -46,6 +49,7 @@ macro_rules! image_ship_field {
 image_ship_field!(infinity_filter: InfinityFilter);
 image_ship_field!(compensation: Compensation);
 image_ship_field!(pixel_depth: PixelDepth);
+image_ship_field!(edge_sharpen: EdgeSharpen);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -54,6 +58,7 @@ impl ImageShip {
             infinity_filter: None,
             compensation: None,
             pixel_depth: None,
+            edge_sharpen: None,
         }
     }
 
@@ -63,6 +68,7 @@ impl ImageShip {
             infinity_filter: Some(val),
             compensation: self.compensation,
             pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
         }
     }
 
@@ -72,6 +78,7 @@ impl ImageShip {
             infinity_filter: self.infinity_filter,
             compensation: Some(val),
             pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
         }
     }
 
@@ -81,6 +88,17 @@ impl ImageShip {
             infinity_filter: self.infinity_filter,
             compensation: self.compensation,
             pixel_depth: Some(val),
+            edge_sharpen: self.edge_sharpen,
+        }
+    }
+
+    /// Builder function that sets the [EdgeSharpen].
+    pub const fn with_edge_sharpen(self, val: EdgeSharpen) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: Some(val),
         }
     }
 
@@ -101,7 +119,12 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
-        format!("{IMAGE_SHIP}{infinity}{comp}{depth}")
+        let edge = self
+            .edge_sharpen
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
+        format!("{IMAGE_SHIP}{infinity}{comp}{depth}{edge}")
     }
 }
 
@@ -119,11 +142,13 @@ impl TryFrom<&str> for ImageShip {
         let infinity_filter = InfinityFilter::try_from(rem).ok();
         let compensation = Compensation::try_from(rem).ok();
         let pixel_depth = PixelDepth::try_from(rem).ok();
+        let edge_sharpen = EdgeSharpen::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
             compensation,
             pixel_depth,
+            edge_sharpen,
         })
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -3,6 +3,7 @@ use alloc::string::{String, ToString};
 use crate::result::{Error, Result};
 
 mod compensation;
+mod document_filter;
 mod edge_sharpen;
 mod gamma_correction;
 mod histogram_stretch;
@@ -16,6 +17,7 @@ mod pixel_ship;
 mod protocol;
 
 pub use compensation::*;
+pub use document_filter::*;
 pub use edge_sharpen::*;
 pub use gamma_correction::*;
 pub use histogram_stretch::*;
@@ -45,6 +47,7 @@ pub struct ImageShip {
     gamma_correction: Option<GammaCorrection>,
     protocol: Option<Protocol>,
     pixel_ship: Option<PixelShip>,
+    document_filter: Option<DocumentFilter>,
 }
 
 macro_rules! image_ship_field {
@@ -82,6 +85,7 @@ image_ship_field!(jpeg_image_quality: JpegImageQuality);
 image_ship_field!(gamma_correction: GammaCorrection);
 image_ship_field!(protocol: Protocol);
 image_ship_field!(pixel_ship: PixelShip);
+image_ship_field!(document_filter: DocumentFilter);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -99,6 +103,7 @@ impl ImageShip {
             gamma_correction: None,
             protocol: None,
             pixel_ship: None,
+            document_filter: None,
         }
     }
 
@@ -117,6 +122,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -135,6 +141,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -153,6 +160,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -171,6 +179,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -189,6 +198,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -207,6 +217,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -225,6 +236,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -243,6 +255,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -261,6 +274,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -279,6 +293,7 @@ impl ImageShip {
             gamma_correction: Some(val),
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -297,6 +312,7 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: Some(val),
             pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
         }
     }
 
@@ -315,6 +331,26 @@ impl ImageShip {
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
             pixel_ship: Some(val),
+            document_filter: self.document_filter,
+        }
+    }
+
+    /// Builder function that sets the [DocumentFilter].
+    pub const fn with_document_filter(self, val: DocumentFilter) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
+            histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
+            gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
+            document_filter: Some(val),
         }
     }
 
@@ -380,8 +416,13 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
+        let doc = self
+            .document_filter
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
         format!(
-            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}{gamma}{proto}{pixel}"
+            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}{gamma}{proto}{pixel}{doc}"
         )
     }
 }
@@ -409,6 +450,7 @@ impl TryFrom<&str> for ImageShip {
         let gamma_correction = GammaCorrection::try_from(rem).ok();
         let protocol = Protocol::try_from(rem).ok();
         let pixel_ship = PixelShip::try_from(rem).ok();
+        let document_filter = DocumentFilter::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
@@ -423,6 +465,7 @@ impl TryFrom<&str> for ImageShip {
             gamma_correction,
             protocol,
             pixel_ship,
+            document_filter,
         })
     }
 }
@@ -458,9 +501,10 @@ mod tests {
         let exp_gamma_correction = GammaCorrection::new();
         let exp_protocol = Protocol::new();
         let exp_pixel_ship = PixelShip::new();
+        let exp_document_filter = DocumentFilter::new();
 
         [
-            "", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K", "0P", "1S",
+            "", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K", "0P", "1S", "0U",
         ]
         .into_iter()
         .map(|s| format!("{IMAGE_SHIP}{s}"))
@@ -477,6 +521,7 @@ mod tests {
             ImageShip::new().with_gamma_correction(exp_gamma_correction),
             ImageShip::new().with_protocol(exp_protocol),
             ImageShip::new().with_pixel_ship(exp_pixel_ship),
+            ImageShip::new().with_document_filter(exp_document_filter),
         ])
         .for_each(|(img_str, exp_img_ship)| {
             assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
@@ -496,5 +541,6 @@ mod tests {
         test_image_ship_field!(img, gamma_correction, exp_gamma_correction);
         test_image_ship_field!(img, protocol, exp_protocol);
         test_image_ship_field!(img, pixel_ship, exp_pixel_ship);
+        test_image_ship_field!(img, document_filter, exp_document_filter);
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -7,6 +7,7 @@ mod compensation;
 mod document_filter;
 mod edge_sharpen;
 mod gamma_correction;
+mod histogram_ship;
 mod histogram_stretch;
 mod image_rotate;
 mod infinity_filter;
@@ -22,6 +23,7 @@ pub use compensation::*;
 pub use document_filter::*;
 pub use edge_sharpen::*;
 pub use gamma_correction::*;
+pub use histogram_ship::*;
 pub use histogram_stretch::*;
 pub use image_rotate::*;
 pub use infinity_filter::*;
@@ -51,6 +53,7 @@ pub struct ImageShip {
     pixel_ship: Option<PixelShip>,
     document_filter: Option<DocumentFilter>,
     blur_image: Option<BlurImage>,
+    histogram_ship: Option<HistogramShip>,
 }
 
 macro_rules! image_ship_field {
@@ -90,6 +93,7 @@ image_ship_field!(protocol: Protocol);
 image_ship_field!(pixel_ship: PixelShip);
 image_ship_field!(document_filter: DocumentFilter);
 image_ship_field!(blur_image: BlurImage);
+image_ship_field!(histogram_ship: HistogramShip);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -109,6 +113,7 @@ impl ImageShip {
             pixel_ship: None,
             document_filter: None,
             blur_image: None,
+            histogram_ship: None,
         }
     }
 
@@ -129,6 +134,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -149,6 +155,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -169,6 +176,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -189,6 +197,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -209,6 +218,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -229,6 +239,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -249,6 +260,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -269,6 +281,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -289,6 +302,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -309,6 +323,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -329,6 +344,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -349,6 +365,7 @@ impl ImageShip {
             pixel_ship: Some(val),
             document_filter: self.document_filter,
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -369,6 +386,7 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: Some(val),
             blur_image: self.blur_image,
+            histogram_ship: self.histogram_ship,
         }
     }
 
@@ -389,6 +407,28 @@ impl ImageShip {
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
             blur_image: Some(val),
+            histogram_ship: self.histogram_ship,
+        }
+    }
+
+    /// Builder function that sets the [HistogramShip].
+    pub const fn with_histogram_ship(self, val: HistogramShip) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
+            histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
+            gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
+            blur_image: self.blur_image,
+            histogram_ship: Some(val),
         }
     }
 
@@ -414,7 +454,7 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
-        let histo = self
+        let histo_stretch = self
             .histogram_stretch
             .map(|v| v.command().to_string())
             .unwrap_or_default();
@@ -464,8 +504,13 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
+        let histo_ship = self
+            .histogram_ship
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
         format!(
-            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}{gamma}{proto}{pixel}{doc}{blur}"
+            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo_stretch}{invert}{noise}{rotate}{jpeg}{gamma}{proto}{pixel}{doc}{blur}{histo_ship}"
         )
     }
 }
@@ -495,6 +540,7 @@ impl TryFrom<&str> for ImageShip {
         let pixel_ship = PixelShip::try_from(rem).ok();
         let document_filter = DocumentFilter::try_from(rem).ok();
         let blur_image = BlurImage::try_from(rem).ok();
+        let histogram_ship = HistogramShip::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
@@ -511,6 +557,7 @@ impl TryFrom<&str> for ImageShip {
             pixel_ship,
             document_filter,
             blur_image,
+            histogram_ship,
         })
     }
 }
@@ -548,9 +595,11 @@ mod tests {
         let exp_pixel_ship = PixelShip::new();
         let exp_document_filter = DocumentFilter::new();
         let exp_blur_image = BlurImage::new();
+        let exp_histogram_ship = HistogramShip::new();
 
         [
-            "", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K", "0P", "1S", "0U",
+            "", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K", "0P", "1S", "0U", "0V",
+            "0W",
         ]
         .into_iter()
         .map(|s| format!("{IMAGE_SHIP}{s}"))
@@ -569,6 +618,7 @@ mod tests {
             ImageShip::new().with_pixel_ship(exp_pixel_ship),
             ImageShip::new().with_document_filter(exp_document_filter),
             ImageShip::new().with_blur_image(exp_blur_image),
+            ImageShip::new().with_histogram_ship(exp_histogram_ship),
         ])
         .for_each(|(img_str, exp_img_ship)| {
             assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
@@ -590,5 +640,6 @@ mod tests {
         test_image_ship_field!(img, pixel_ship, exp_pixel_ship);
         test_image_ship_field!(img, document_filter, exp_document_filter);
         test_image_ship_field!(img, blur_image, exp_blur_image);
+        test_image_ship_field!(img, histogram_ship, exp_histogram_ship);
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -12,6 +12,7 @@ mod invert_image;
 mod jpeg_image_quality;
 mod noise_reduction;
 mod pixel_depth;
+mod protocol;
 
 pub use compensation::*;
 pub use edge_sharpen::*;
@@ -23,6 +24,7 @@ pub use invert_image::*;
 pub use jpeg_image_quality::*;
 pub use noise_reduction::*;
 pub use pixel_depth::*;
+pub use protocol::*;
 
 const IMAGE_SHIP: &str = "IMGSHP";
 
@@ -39,6 +41,7 @@ pub struct ImageShip {
     image_rotate: Option<ImageRotate>,
     jpeg_image_quality: Option<JpegImageQuality>,
     gamma_correction: Option<GammaCorrection>,
+    protocol: Option<Protocol>,
 }
 
 macro_rules! image_ship_field {
@@ -74,6 +77,7 @@ image_ship_field!(noise_reduction: NoiseReduction);
 image_ship_field!(image_rotate: ImageRotate);
 image_ship_field!(jpeg_image_quality: JpegImageQuality);
 image_ship_field!(gamma_correction: GammaCorrection);
+image_ship_field!(protocol: Protocol);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -89,6 +93,7 @@ impl ImageShip {
             image_rotate: None,
             jpeg_image_quality: None,
             gamma_correction: None,
+            protocol: None,
         }
     }
 
@@ -105,6 +110,7 @@ impl ImageShip {
             image_rotate: self.image_rotate,
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
         }
     }
 
@@ -121,6 +127,7 @@ impl ImageShip {
             image_rotate: self.image_rotate,
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
         }
     }
 
@@ -137,6 +144,7 @@ impl ImageShip {
             image_rotate: self.image_rotate,
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
         }
     }
 
@@ -153,6 +161,7 @@ impl ImageShip {
             image_rotate: self.image_rotate,
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
         }
     }
 
@@ -169,6 +178,7 @@ impl ImageShip {
             image_rotate: self.image_rotate,
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
         }
     }
 
@@ -185,6 +195,7 @@ impl ImageShip {
             image_rotate: self.image_rotate,
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
         }
     }
 
@@ -201,6 +212,7 @@ impl ImageShip {
             image_rotate: self.image_rotate,
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
         }
     }
 
@@ -217,6 +229,7 @@ impl ImageShip {
             image_rotate: Some(val),
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
         }
     }
 
@@ -233,6 +246,7 @@ impl ImageShip {
             image_rotate: self.image_rotate,
             jpeg_image_quality: Some(val),
             gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
         }
     }
 
@@ -249,6 +263,24 @@ impl ImageShip {
             image_rotate: self.image_rotate,
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: Some(val),
+            protocol: self.protocol,
+        }
+    }
+
+    /// Builder function that sets the [Protocol].
+    pub const fn with_protocol(self, val: Protocol) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
+            histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
+            gamma_correction: self.gamma_correction,
+            protocol: Some(val),
         }
     }
 
@@ -304,8 +336,13 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
+        let proto = self
+            .protocol
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
         format!(
-            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}{gamma}"
+            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}{gamma}{proto}"
         )
     }
 }
@@ -331,6 +368,7 @@ impl TryFrom<&str> for ImageShip {
         let image_rotate = ImageRotate::try_from(rem).ok();
         let jpeg_image_quality = JpegImageQuality::try_from(rem).ok();
         let gamma_correction = GammaCorrection::try_from(rem).ok();
+        let protocol = Protocol::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
@@ -343,6 +381,7 @@ impl TryFrom<&str> for ImageShip {
             image_rotate,
             jpeg_image_quality,
             gamma_correction,
+            protocol,
         })
     }
 }
@@ -376,26 +415,30 @@ mod tests {
         let exp_image_rotate = ImageRotate::new();
         let exp_jpeg_image_quality = JpegImageQuality::new();
         let exp_gamma_correction = GammaCorrection::new();
+        let exp_protocol = Protocol::new();
 
-        ["", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K"]
-            .into_iter()
-            .map(|s| format!("{IMAGE_SHIP}{s}"))
-            .zip([
-                ImageShip::new(),
-                ImageShip::new().with_infinity_filter(exp_infinity_filter),
-                ImageShip::new().with_compensation(exp_compensation),
-                ImageShip::new().with_pixel_depth(exp_pixel_depth),
-                ImageShip::new().with_histogram_stretch(exp_histogram_stretch),
-                ImageShip::new().with_invert_image(exp_invert_image),
-                ImageShip::new().with_noise_reduction(exp_noise_reduction),
-                ImageShip::new().with_image_rotate(exp_image_rotate),
-                ImageShip::new().with_jpeg_image_quality(exp_jpeg_image_quality),
-                ImageShip::new().with_gamma_correction(exp_gamma_correction),
-            ])
-            .for_each(|(img_str, exp_img_ship)| {
-                assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
-                assert_eq!(exp_img_ship.command(), img_str);
-            });
+        [
+            "", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K", "0P",
+        ]
+        .into_iter()
+        .map(|s| format!("{IMAGE_SHIP}{s}"))
+        .zip([
+            ImageShip::new(),
+            ImageShip::new().with_infinity_filter(exp_infinity_filter),
+            ImageShip::new().with_compensation(exp_compensation),
+            ImageShip::new().with_pixel_depth(exp_pixel_depth),
+            ImageShip::new().with_histogram_stretch(exp_histogram_stretch),
+            ImageShip::new().with_invert_image(exp_invert_image),
+            ImageShip::new().with_noise_reduction(exp_noise_reduction),
+            ImageShip::new().with_image_rotate(exp_image_rotate),
+            ImageShip::new().with_jpeg_image_quality(exp_jpeg_image_quality),
+            ImageShip::new().with_gamma_correction(exp_gamma_correction),
+            ImageShip::new().with_protocol(exp_protocol),
+        ])
+        .for_each(|(img_str, exp_img_ship)| {
+            assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
+            assert_eq!(exp_img_ship.command(), img_str);
+        });
 
         let mut img = ImageShip::new();
 
@@ -408,5 +451,6 @@ mod tests {
         test_image_ship_field!(img, image_rotate, exp_image_rotate);
         test_image_ship_field!(img, jpeg_image_quality, exp_jpeg_image_quality);
         test_image_ship_field!(img, gamma_correction, exp_gamma_correction);
+        test_image_ship_field!(img, protocol, exp_protocol);
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -12,6 +12,7 @@ mod invert_image;
 mod jpeg_image_quality;
 mod noise_reduction;
 mod pixel_depth;
+mod pixel_ship;
 mod protocol;
 
 pub use compensation::*;
@@ -24,6 +25,7 @@ pub use invert_image::*;
 pub use jpeg_image_quality::*;
 pub use noise_reduction::*;
 pub use pixel_depth::*;
+pub use pixel_ship::*;
 pub use protocol::*;
 
 const IMAGE_SHIP: &str = "IMGSHP";
@@ -42,6 +44,7 @@ pub struct ImageShip {
     jpeg_image_quality: Option<JpegImageQuality>,
     gamma_correction: Option<GammaCorrection>,
     protocol: Option<Protocol>,
+    pixel_ship: Option<PixelShip>,
 }
 
 macro_rules! image_ship_field {
@@ -78,6 +81,7 @@ image_ship_field!(image_rotate: ImageRotate);
 image_ship_field!(jpeg_image_quality: JpegImageQuality);
 image_ship_field!(gamma_correction: GammaCorrection);
 image_ship_field!(protocol: Protocol);
+image_ship_field!(pixel_ship: PixelShip);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -94,6 +98,7 @@ impl ImageShip {
             jpeg_image_quality: None,
             gamma_correction: None,
             protocol: None,
+            pixel_ship: None,
         }
     }
 
@@ -111,6 +116,7 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -128,6 +134,7 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -145,6 +152,7 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -162,6 +170,7 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -179,6 +188,7 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -196,6 +206,7 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -213,6 +224,7 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -230,6 +242,7 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -247,6 +260,7 @@ impl ImageShip {
             jpeg_image_quality: Some(val),
             gamma_correction: self.gamma_correction,
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -264,6 +278,7 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: Some(val),
             protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
         }
     }
 
@@ -281,6 +296,25 @@ impl ImageShip {
             jpeg_image_quality: self.jpeg_image_quality,
             gamma_correction: self.gamma_correction,
             protocol: Some(val),
+            pixel_ship: self.pixel_ship,
+        }
+    }
+
+    /// Builder function that sets the [PixelShip].
+    pub const fn with_pixel_ship(self, val: PixelShip) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
+            histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
+            gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
+            pixel_ship: Some(val),
         }
     }
 
@@ -341,8 +375,13 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
+        let pixel = self
+            .pixel_ship
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
         format!(
-            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}{gamma}{proto}"
+            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}{gamma}{proto}{pixel}"
         )
     }
 }
@@ -369,6 +408,7 @@ impl TryFrom<&str> for ImageShip {
         let jpeg_image_quality = JpegImageQuality::try_from(rem).ok();
         let gamma_correction = GammaCorrection::try_from(rem).ok();
         let protocol = Protocol::try_from(rem).ok();
+        let pixel_ship = PixelShip::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
@@ -382,6 +422,7 @@ impl TryFrom<&str> for ImageShip {
             jpeg_image_quality,
             gamma_correction,
             protocol,
+            pixel_ship,
         })
     }
 }
@@ -416,9 +457,10 @@ mod tests {
         let exp_jpeg_image_quality = JpegImageQuality::new();
         let exp_gamma_correction = GammaCorrection::new();
         let exp_protocol = Protocol::new();
+        let exp_pixel_ship = PixelShip::new();
 
         [
-            "", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K", "0P",
+            "", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K", "0P", "1S",
         ]
         .into_iter()
         .map(|s| format!("{IMAGE_SHIP}{s}"))
@@ -434,6 +476,7 @@ mod tests {
             ImageShip::new().with_jpeg_image_quality(exp_jpeg_image_quality),
             ImageShip::new().with_gamma_correction(exp_gamma_correction),
             ImageShip::new().with_protocol(exp_protocol),
+            ImageShip::new().with_pixel_ship(exp_pixel_ship),
         ])
         .for_each(|(img_str, exp_img_ship)| {
             assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
@@ -452,5 +495,6 @@ mod tests {
         test_image_ship_field!(img, jpeg_image_quality, exp_jpeg_image_quality);
         test_image_ship_field!(img, gamma_correction, exp_gamma_correction);
         test_image_ship_field!(img, protocol, exp_protocol);
+        test_image_ship_field!(img, pixel_ship, exp_pixel_ship);
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -57,7 +57,7 @@ pub struct ImageShip {
 }
 
 macro_rules! image_ship_field {
-    ($field:ident: $field_ty:ty) => {
+    ($field:ident: $field_ty:ty, [$($not_field:ident$(,)?)+]$(,)?) => {
         paste::paste! {
             impl ImageShip {
                 #[doc = "Gets the [" $field_ty "] for [ImageShip]."]
@@ -74,26 +74,318 @@ macro_rules! image_ship_field {
                 pub fn [<unset_ $field>](&mut self) {
                     self.$field = None;
                 }
+
+                #[doc = "Builder function that sets the [" $field_ty "] for [ImageShip]."]
+                pub const fn [<with_ $field>](self, val: $field_ty) -> Self {
+                    Self {
+                        $field: Some(val),
+                        $($not_field: self.$not_field,)+
+                    }
+                }
             }
         }
     };
 }
 
-image_ship_field!(infinity_filter: InfinityFilter);
-image_ship_field!(compensation: Compensation);
-image_ship_field!(pixel_depth: PixelDepth);
-image_ship_field!(edge_sharpen: EdgeSharpen);
-image_ship_field!(histogram_stretch: HistogramStretch);
-image_ship_field!(invert_image: InvertImage);
-image_ship_field!(noise_reduction: NoiseReduction);
-image_ship_field!(image_rotate: ImageRotate);
-image_ship_field!(jpeg_image_quality: JpegImageQuality);
-image_ship_field!(gamma_correction: GammaCorrection);
-image_ship_field!(protocol: Protocol);
-image_ship_field!(pixel_ship: PixelShip);
-image_ship_field!(document_filter: DocumentFilter);
-image_ship_field!(blur_image: BlurImage);
-image_ship_field!(histogram_ship: HistogramShip);
+image_ship_field! {
+    infinity_filter: InfinityFilter,
+    [
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    compensation: Compensation,
+    [
+        infinity_filter,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    pixel_depth: PixelDepth,
+    [
+        infinity_filter,
+        compensation,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    edge_sharpen: EdgeSharpen,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    histogram_stretch: HistogramStretch,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    invert_image: InvertImage,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    noise_reduction: NoiseReduction,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    image_rotate: ImageRotate,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    jpeg_image_quality: JpegImageQuality,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    gamma_correction: GammaCorrection,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    protocol: Protocol,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        pixel_ship,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    pixel_ship: PixelShip,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        document_filter,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    document_filter: DocumentFilter,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        blur_image,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    blur_image: BlurImage,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        histogram_ship,
+    ],
+}
+
+image_ship_field! {
+    histogram_ship: HistogramShip,
+    [
+        infinity_filter,
+        compensation,
+        pixel_depth,
+        edge_sharpen,
+        histogram_stretch,
+        invert_image,
+        noise_reduction,
+        image_rotate,
+        jpeg_image_quality,
+        gamma_correction,
+        protocol,
+        pixel_ship,
+        document_filter,
+        blur_image,
+    ],
+}
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -114,321 +406,6 @@ impl ImageShip {
             document_filter: None,
             blur_image: None,
             histogram_ship: None,
-        }
-    }
-
-    /// Builder function that sets the [InfinityFilter].
-    pub const fn with_infinity_filter(self, val: InfinityFilter) -> Self {
-        Self {
-            infinity_filter: Some(val),
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [Compensation].
-    pub const fn with_compensation(self, val: Compensation) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: Some(val),
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [PixelDepth].
-    pub const fn with_pixel_depth(self, val: PixelDepth) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: Some(val),
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [EdgeSharpen].
-    pub const fn with_edge_sharpen(self, val: EdgeSharpen) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: Some(val),
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [HistogramStretch].
-    pub const fn with_histogram_stretch(self, val: HistogramStretch) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: Some(val),
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [InvertImage].
-    pub const fn with_invert_image(self, val: InvertImage) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: Some(val),
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [NoiseReduction].
-    pub const fn with_noise_reduction(self, val: NoiseReduction) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: Some(val),
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [ImageRotate].
-    pub const fn with_image_rotate(self, val: ImageRotate) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: Some(val),
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [JpegImageQuality].
-    pub const fn with_jpeg_image_quality(self, val: JpegImageQuality) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: Some(val),
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [GammaCorrection].
-    pub const fn with_gamma_correction(self, val: GammaCorrection) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: Some(val),
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [Protocol].
-    pub const fn with_protocol(self, val: Protocol) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: Some(val),
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [PixelShip].
-    pub const fn with_pixel_ship(self, val: PixelShip) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: Some(val),
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [DocumentFilter].
-    pub const fn with_document_filter(self, val: DocumentFilter) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: Some(val),
-            blur_image: self.blur_image,
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [BlurImage].
-    pub const fn with_blur_image(self, val: BlurImage) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: Some(val),
-            histogram_ship: self.histogram_ship,
-        }
-    }
-
-    /// Builder function that sets the [HistogramShip].
-    pub const fn with_histogram_ship(self, val: HistogramShip) -> Self {
-        Self {
-            infinity_filter: self.infinity_filter,
-            compensation: self.compensation,
-            pixel_depth: self.pixel_depth,
-            edge_sharpen: self.edge_sharpen,
-            histogram_stretch: self.histogram_stretch,
-            invert_image: self.invert_image,
-            noise_reduction: self.noise_reduction,
-            image_rotate: self.image_rotate,
-            jpeg_image_quality: self.jpeg_image_quality,
-            gamma_correction: self.gamma_correction,
-            protocol: self.protocol,
-            pixel_ship: self.pixel_ship,
-            document_filter: self.document_filter,
-            blur_image: self.blur_image,
-            histogram_ship: Some(val),
         }
     }
 

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -2,6 +2,7 @@ use alloc::string::{String, ToString};
 
 use crate::result::{Error, Result};
 
+mod blur_image;
 mod compensation;
 mod document_filter;
 mod edge_sharpen;
@@ -16,6 +17,7 @@ mod pixel_depth;
 mod pixel_ship;
 mod protocol;
 
+pub use blur_image::*;
 pub use compensation::*;
 pub use document_filter::*;
 pub use edge_sharpen::*;
@@ -48,6 +50,7 @@ pub struct ImageShip {
     protocol: Option<Protocol>,
     pixel_ship: Option<PixelShip>,
     document_filter: Option<DocumentFilter>,
+    blur_image: Option<BlurImage>,
 }
 
 macro_rules! image_ship_field {
@@ -86,6 +89,7 @@ image_ship_field!(gamma_correction: GammaCorrection);
 image_ship_field!(protocol: Protocol);
 image_ship_field!(pixel_ship: PixelShip);
 image_ship_field!(document_filter: DocumentFilter);
+image_ship_field!(blur_image: BlurImage);
 
 impl ImageShip {
     /// Creates a new [ImageShip].
@@ -104,6 +108,7 @@ impl ImageShip {
             protocol: None,
             pixel_ship: None,
             document_filter: None,
+            blur_image: None,
         }
     }
 
@@ -123,6 +128,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -142,6 +148,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -161,6 +168,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -180,6 +188,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -199,6 +208,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -218,6 +228,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -237,6 +248,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -256,6 +268,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -275,6 +288,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -294,6 +308,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -313,6 +328,7 @@ impl ImageShip {
             protocol: Some(val),
             pixel_ship: self.pixel_ship,
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -332,6 +348,7 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: Some(val),
             document_filter: self.document_filter,
+            blur_image: self.blur_image,
         }
     }
 
@@ -351,6 +368,27 @@ impl ImageShip {
             protocol: self.protocol,
             pixel_ship: self.pixel_ship,
             document_filter: Some(val),
+            blur_image: self.blur_image,
+        }
+    }
+
+    /// Builder function that sets the [BlurImage].
+    pub const fn with_blur_image(self, val: BlurImage) -> Self {
+        Self {
+            infinity_filter: self.infinity_filter,
+            compensation: self.compensation,
+            pixel_depth: self.pixel_depth,
+            edge_sharpen: self.edge_sharpen,
+            histogram_stretch: self.histogram_stretch,
+            invert_image: self.invert_image,
+            noise_reduction: self.noise_reduction,
+            image_rotate: self.image_rotate,
+            jpeg_image_quality: self.jpeg_image_quality,
+            gamma_correction: self.gamma_correction,
+            protocol: self.protocol,
+            pixel_ship: self.pixel_ship,
+            document_filter: self.document_filter,
+            blur_image: Some(val),
         }
     }
 
@@ -421,8 +459,13 @@ impl ImageShip {
             .map(|v| v.command().to_string())
             .unwrap_or_default();
 
+        let blur = self
+            .blur_image
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
         format!(
-            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}{gamma}{proto}{pixel}{doc}"
+            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo}{invert}{noise}{rotate}{jpeg}{gamma}{proto}{pixel}{doc}{blur}"
         )
     }
 }
@@ -451,6 +494,7 @@ impl TryFrom<&str> for ImageShip {
         let protocol = Protocol::try_from(rem).ok();
         let pixel_ship = PixelShip::try_from(rem).ok();
         let document_filter = DocumentFilter::try_from(rem).ok();
+        let blur_image = BlurImage::try_from(rem).ok();
 
         Ok(Self {
             infinity_filter,
@@ -466,6 +510,7 @@ impl TryFrom<&str> for ImageShip {
             protocol,
             pixel_ship,
             document_filter,
+            blur_image,
         })
     }
 }
@@ -502,6 +547,7 @@ mod tests {
         let exp_protocol = Protocol::new();
         let exp_pixel_ship = PixelShip::new();
         let exp_document_filter = DocumentFilter::new();
+        let exp_blur_image = BlurImage::new();
 
         [
             "", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K", "0P", "1S", "0U",
@@ -522,6 +568,7 @@ mod tests {
             ImageShip::new().with_protocol(exp_protocol),
             ImageShip::new().with_pixel_ship(exp_pixel_ship),
             ImageShip::new().with_document_filter(exp_document_filter),
+            ImageShip::new().with_blur_image(exp_blur_image),
         ])
         .for_each(|(img_str, exp_img_ship)| {
             assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
@@ -542,5 +589,6 @@ mod tests {
         test_image_ship_field!(img, protocol, exp_protocol);
         test_image_ship_field!(img, pixel_ship, exp_pixel_ship);
         test_image_ship_field!(img, document_filter, exp_document_filter);
+        test_image_ship_field!(img, blur_image, exp_blur_image);
     }
 }

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -1,0 +1,123 @@
+use alloc::string::{String, ToString};
+
+use crate::result::{Error, Result};
+
+mod infinity_filter;
+
+pub use infinity_filter::*;
+
+const IMAGE_SHIP: &str = "IMGSHP";
+
+/// Configure all barcode `Image Ship` encodings.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ImageShip {
+    infinity_filter: Option<InfinityFilter>,
+}
+
+macro_rules! image_ship_field {
+    ($field:ident: $field_ty:ty) => {
+        paste::paste! {
+            impl ImageShip {
+                #[doc = "Gets the [" $field_ty "] for [ImageShip]."]
+                pub const fn $field(&self) -> Option<$field_ty> {
+                    self.$field
+                }
+
+                #[doc = "Sets the [" $field_ty "] for [ImageShip]."]
+                pub fn [<set_ $field>](&mut self, val: $field_ty) {
+                    self.$field = Some(val);
+                }
+
+                #[doc = "Unsets the [" $field_ty "] for [ImageShip]."]
+                pub fn [<unset_ $field>](&mut self) {
+                    self.$field = None;
+                }
+            }
+        }
+    };
+}
+
+impl ImageShip {
+    /// Creates a new [ImageShip].
+    pub const fn new() -> Self {
+        Self {
+            infinity_filter: None,
+        }
+    }
+
+    /// Builder function that sets the [InfinityFilter].
+    pub const fn with_infinity_filter(self, val: InfinityFilter) -> Self {
+        Self {
+            infinity_filter: Some(val),
+        }
+    }
+
+    /// Gets the ASCII serial command code for [ImageShip].
+    pub fn command(&self) -> String {
+        let infinity = self
+            .infinity_filter
+            .map(|v| v.command().to_string())
+            .unwrap_or_default();
+
+        format!("{IMAGE_SHIP}{infinity}")
+    }
+}
+
+image_ship_field!(infinity_filter: InfinityFilter);
+
+impl Default for ImageShip {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for ImageShip {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        let rem = val.strip_prefix(IMAGE_SHIP).ok_or(Error::InvalidVariant)?;
+        let infinity_filter = InfinityFilter::try_from(rem).ok();
+
+        Ok(Self { infinity_filter })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_image_ship_field {
+        ($img:ident, $field:ident, $field_val:expr) => {
+            paste::paste! {
+                assert!($img.$field().is_none());
+
+                $img.[<set_ $field>]($field_val);
+                assert_eq!($img.$field(), Some($field_val));
+
+                $img.[<unset_ $field>]();
+                assert!($img.$field().is_none());
+            }
+        };
+    }
+
+    #[test]
+    fn test_valid() {
+        let exp_infinity_filter = InfinityFilter::new();
+
+        ["", "0A"]
+            .into_iter()
+            .map(|s| format!("{IMAGE_SHIP}{s}"))
+            .zip([
+                ImageShip::new(),
+                ImageShip::new().with_infinity_filter(exp_infinity_filter),
+            ])
+            .for_each(|(img_str, exp_img_ship)| {
+                assert_eq!(ImageShip::try_from(img_str.as_str()), Ok(exp_img_ship));
+                assert_eq!(exp_img_ship.command(), img_str);
+            });
+
+        let mut img = ImageShip::new();
+
+        test_image_ship_field!(img, infinity_filter, exp_infinity_filter);
+    }
+}

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -1,6 +1,7 @@
 use alloc::string::{String, ToString};
 
 use crate::result::{Error, Result};
+use crate::modifier_field;
 
 mod blur_image;
 mod compensation;
@@ -56,38 +57,8 @@ pub struct ImageShip {
     histogram_ship: Option<HistogramShip>,
 }
 
-macro_rules! image_ship_field {
-    ($field:ident: $field_ty:ty, [$($not_field:ident$(,)?)+]$(,)?) => {
-        paste::paste! {
-            impl ImageShip {
-                #[doc = "Gets the [" $field_ty "] for [ImageShip]."]
-                pub const fn $field(&self) -> Option<$field_ty> {
-                    self.$field
-                }
-
-                #[doc = "Sets the [" $field_ty "] for [ImageShip]."]
-                pub fn [<set_ $field>](&mut self, val: $field_ty) {
-                    self.$field = Some(val);
-                }
-
-                #[doc = "Unsets the [" $field_ty "] for [ImageShip]."]
-                pub fn [<unset_ $field>](&mut self) {
-                    self.$field = None;
-                }
-
-                #[doc = "Builder function that sets the [" $field_ty "] for [ImageShip]."]
-                pub const fn [<with_ $field>](self, val: $field_ty) -> Self {
-                    Self {
-                        $field: Some(val),
-                        $($not_field: self.$not_field,)+
-                    }
-                }
-            }
-        }
-    };
-}
-
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     infinity_filter: InfinityFilter,
     [
         compensation,
@@ -107,7 +78,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     compensation: Compensation,
     [
         infinity_filter,
@@ -127,7 +99,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     pixel_depth: PixelDepth,
     [
         infinity_filter,
@@ -147,7 +120,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     edge_sharpen: EdgeSharpen,
     [
         infinity_filter,
@@ -167,7 +141,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     histogram_stretch: HistogramStretch,
     [
         infinity_filter,
@@ -187,7 +162,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     invert_image: InvertImage,
     [
         infinity_filter,
@@ -207,7 +183,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     noise_reduction: NoiseReduction,
     [
         infinity_filter,
@@ -227,7 +204,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     image_rotate: ImageRotate,
     [
         infinity_filter,
@@ -247,7 +225,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     jpeg_image_quality: JpegImageQuality,
     [
         infinity_filter,
@@ -267,7 +246,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     gamma_correction: GammaCorrection,
     [
         infinity_filter,
@@ -287,7 +267,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     protocol: Protocol,
     [
         infinity_filter,
@@ -307,7 +288,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     pixel_ship: PixelShip,
     [
         infinity_filter,
@@ -327,7 +309,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     document_filter: DocumentFilter,
     [
         infinity_filter,
@@ -347,7 +330,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     blur_image: BlurImage,
     [
         infinity_filter,
@@ -367,7 +351,8 @@ image_ship_field! {
     ],
 }
 
-image_ship_field! {
+modifier_field! {
+    ImageShip,
     histogram_ship: HistogramShip,
     [
         infinity_filter,

--- a/src/command/image_ship.rs
+++ b/src/command/image_ship.rs
@@ -1,7 +1,4 @@
-use alloc::string::{String, ToString};
-
-use crate::result::{Error, Result};
-use crate::modifier_field;
+use crate::{modifier_command, modifier_field};
 
 mod blur_image;
 mod compensation;
@@ -35,26 +32,25 @@ pub use pixel_depth::*;
 pub use pixel_ship::*;
 pub use protocol::*;
 
-const IMAGE_SHIP: &str = "IMGSHP";
-
-/// Configure all barcode `Image Ship` encodings.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ImageShip {
-    infinity_filter: Option<InfinityFilter>,
-    compensation: Option<Compensation>,
-    pixel_depth: Option<PixelDepth>,
-    edge_sharpen: Option<EdgeSharpen>,
-    histogram_stretch: Option<HistogramStretch>,
-    invert_image: Option<InvertImage>,
-    noise_reduction: Option<NoiseReduction>,
-    image_rotate: Option<ImageRotate>,
-    jpeg_image_quality: Option<JpegImageQuality>,
-    gamma_correction: Option<GammaCorrection>,
-    protocol: Option<Protocol>,
-    pixel_ship: Option<PixelShip>,
-    document_filter: Option<DocumentFilter>,
-    blur_image: Option<BlurImage>,
-    histogram_ship: Option<HistogramShip>,
+modifier_command! {
+    /// Configure all barcode `Image Ship` encodings.
+    ImageShip: "IMGSHP" {
+        infinity_filter: InfinityFilter,
+        compensation: Compensation,
+        pixel_depth: PixelDepth,
+        edge_sharpen: EdgeSharpen,
+        histogram_stretch: HistogramStretch,
+        invert_image: InvertImage,
+        noise_reduction: NoiseReduction,
+        image_rotate: ImageRotate,
+        jpeg_image_quality: JpegImageQuality,
+        gamma_correction: GammaCorrection,
+        protocol: Protocol,
+        pixel_ship: PixelShip,
+        document_filter: DocumentFilter,
+        blur_image: BlurImage,
+        histogram_ship: HistogramShip,
+    }
 }
 
 modifier_field! {
@@ -372,158 +368,6 @@ modifier_field! {
     ],
 }
 
-impl ImageShip {
-    /// Creates a new [ImageShip].
-    pub const fn new() -> Self {
-        Self {
-            infinity_filter: None,
-            compensation: None,
-            pixel_depth: None,
-            edge_sharpen: None,
-            histogram_stretch: None,
-            invert_image: None,
-            noise_reduction: None,
-            image_rotate: None,
-            jpeg_image_quality: None,
-            gamma_correction: None,
-            protocol: None,
-            pixel_ship: None,
-            document_filter: None,
-            blur_image: None,
-            histogram_ship: None,
-        }
-    }
-
-    /// Gets the ASCII serial command code for [ImageShip].
-    pub fn command(&self) -> String {
-        let infinity = self
-            .infinity_filter
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let comp = self
-            .compensation
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let depth = self
-            .pixel_depth
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let edge = self
-            .edge_sharpen
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let histo_stretch = self
-            .histogram_stretch
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let invert = self
-            .invert_image
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let noise = self
-            .noise_reduction
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let rotate = self
-            .image_rotate
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let jpeg = self
-            .jpeg_image_quality
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let gamma = self
-            .gamma_correction
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let proto = self
-            .protocol
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let pixel = self
-            .pixel_ship
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let doc = self
-            .document_filter
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let blur = self
-            .blur_image
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let histo_ship = self
-            .histogram_ship
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        format!(
-            "{IMAGE_SHIP}{infinity}{comp}{depth}{edge}{histo_stretch}{invert}{noise}{rotate}{jpeg}{gamma}{proto}{pixel}{doc}{blur}{histo_ship}"
-        )
-    }
-}
-
-impl Default for ImageShip {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl TryFrom<&str> for ImageShip {
-    type Error = Error;
-
-    fn try_from(val: &str) -> Result<Self> {
-        let rem = val.strip_prefix(IMAGE_SHIP).ok_or(Error::InvalidVariant)?;
-        let infinity_filter = InfinityFilter::try_from(rem).ok();
-        let compensation = Compensation::try_from(rem).ok();
-        let pixel_depth = PixelDepth::try_from(rem).ok();
-        let edge_sharpen = EdgeSharpen::try_from(rem).ok();
-        let histogram_stretch = HistogramStretch::try_from(rem).ok();
-        let invert_image = InvertImage::try_from(rem).ok();
-        let noise_reduction = NoiseReduction::try_from(rem).ok();
-        let image_rotate = ImageRotate::try_from(rem).ok();
-        let jpeg_image_quality = JpegImageQuality::try_from(rem).ok();
-        let gamma_correction = GammaCorrection::try_from(rem).ok();
-        let protocol = Protocol::try_from(rem).ok();
-        let pixel_ship = PixelShip::try_from(rem).ok();
-        let document_filter = DocumentFilter::try_from(rem).ok();
-        let blur_image = BlurImage::try_from(rem).ok();
-        let histogram_ship = HistogramShip::try_from(rem).ok();
-
-        Ok(Self {
-            infinity_filter,
-            compensation,
-            pixel_depth,
-            edge_sharpen,
-            histogram_stretch,
-            invert_image,
-            noise_reduction,
-            image_rotate,
-            jpeg_image_quality,
-            gamma_correction,
-            protocol,
-            pixel_ship,
-            document_filter,
-            blur_image,
-            histogram_ship,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -558,13 +402,14 @@ mod tests {
         let exp_document_filter = DocumentFilter::new();
         let exp_blur_image = BlurImage::new();
         let exp_histogram_ship = HistogramShip::new();
+        let prefix = ImageShip::prefix();
 
         [
             "", "0A", "0C", "8D", "0H", "1ix", "0if", "0ir", "50J", "0K", "0P", "1S", "0U", "0V",
             "0W",
         ]
         .into_iter()
-        .map(|s| format!("{IMAGE_SHIP}{s}"))
+        .map(|s| format!("{prefix}{s}"))
         .zip([
             ImageShip::new(),
             ImageShip::new().with_infinity_filter(exp_infinity_filter),

--- a/src/command/image_ship/blur_image.rs
+++ b/src/command/image_ship/blur_image.rs
@@ -1,0 +1,62 @@
+use crate::result::{Error, Result};
+
+const BLUR_OFF: &str = "0V";
+const BLUR_ON: &str = "1V";
+
+/// Sets the image ship blur image.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum BlurImage {
+    /// Blur image off.
+    Off,
+    /// Blur image on.
+    On,
+}
+
+impl BlurImage {
+    /// Creates a new [BlurImage].
+    pub const fn new() -> Self {
+        Self::Off
+    }
+
+    /// Gets the ASCII serial command code for [BlurImage].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Off => BLUR_OFF,
+            Self::On => BLUR_ON,
+        }
+    }
+}
+
+impl Default for BlurImage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for BlurImage {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(BLUR_OFF) => Ok(Self::Off),
+            v if v.contains(BLUR_ON) => Ok(Self::On),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [BlurImage::Off, BlurImage::On]
+            .into_iter()
+            .zip([BLUR_OFF, BLUR_ON])
+            .for_each(|(cmd, exp_ascii_cmd)| {
+                assert_eq!(cmd.command(), exp_ascii_cmd);
+                assert_eq!(BlurImage::try_from(exp_ascii_cmd), Ok(cmd));
+            });
+    }
+}

--- a/src/command/image_ship/compensation.rs
+++ b/src/command/image_ship/compensation.rs
@@ -1,0 +1,62 @@
+use crate::result::{Error, Result};
+
+const COMPENSATION_DISABLED: &str = "0C";
+const COMPENSATION_ENABLED: &str = "1C";
+
+/// Sets the image ship compensation.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Compensation {
+    /// Compensation disabled.
+    Disabled,
+    /// Compensation enabled.
+    Enabled,
+}
+
+impl Compensation {
+    /// Creates a new [Compensation].
+    pub const fn new() -> Self {
+        Self::Disabled
+    }
+
+    /// Gets the ASCII serial command code for [Compensation].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Disabled => COMPENSATION_DISABLED,
+            Self::Enabled => COMPENSATION_ENABLED,
+        }
+    }
+}
+
+impl Default for Compensation {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for Compensation {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(COMPENSATION_DISABLED) => Ok(Self::Disabled),
+            v if v.contains(COMPENSATION_ENABLED) => Ok(Self::Enabled),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [Compensation::Disabled, Compensation::Enabled]
+            .into_iter()
+            .zip([COMPENSATION_DISABLED, COMPENSATION_ENABLED])
+            .for_each(|(cmd, exp_ascii_cmd)| {
+                assert_eq!(cmd.command(), exp_ascii_cmd);
+                assert_eq!(Compensation::try_from(exp_ascii_cmd), Ok(cmd));
+            });
+    }
+}

--- a/src/command/image_ship/document_filter.rs
+++ b/src/command/image_ship/document_filter.rs
@@ -1,0 +1,82 @@
+use alloc::string::String;
+
+use crate::result::{Error, Result};
+
+const DOCUMENT_SUFFIX: &str = "U";
+const DOCUMENT_DEFAULT: u8 = 0;
+
+/// Represents the image ship document filter.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct DocumentFilter {
+    threshold: u8,
+}
+
+impl DocumentFilter {
+    /// Creates a new [DocumentFilter].
+    pub const fn new() -> Self {
+        Self {
+            threshold: DOCUMENT_DEFAULT,
+        }
+    }
+
+    /// Gets the [DocumentFilter] threshold setting.
+    pub const fn threshold(&self) -> u8 {
+        self.threshold
+    }
+
+    /// Creates a [DocumentFilter] from a threshold parameter.
+    pub const fn from_threshold(threshold: u8) -> Self {
+        Self { threshold }
+    }
+
+    /// Gets the ASCII serial command code for [DocumentFilter].
+    pub fn command(&self) -> String {
+        let threshold = self.threshold;
+        format!("{threshold}{DOCUMENT_SUFFIX}")
+    }
+}
+
+impl Default for DocumentFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<u8> for DocumentFilter {
+    fn from(val: u8) -> Self {
+        Self::from_threshold(val)
+    }
+}
+
+impl TryFrom<&str> for DocumentFilter {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        let pos = val.find(DOCUMENT_SUFFIX).ok_or(Error::InvalidVariant)?;
+        let exp_start = val[..pos]
+            .rfind(|c: char| c.is_ascii_uppercase() || c.is_ascii_lowercase())
+            .map(|s| s + 1)
+            .unwrap_or(0);
+
+        val[exp_start..pos]
+            .parse::<u8>()
+            .map(Self::from_threshold)
+            .map_err(|_| Error::InvalidVariant)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        (0..=u8::MAX).for_each(|threshold| {
+            let exp_threshold = DocumentFilter { threshold };
+
+            assert_eq!(DocumentFilter::from_threshold(threshold), exp_threshold);
+            assert_eq!(DocumentFilter::from(threshold), exp_threshold);
+            assert_eq!(exp_threshold.threshold(), threshold);
+        });
+    }
+}

--- a/src/command/image_ship/edge_sharpen.rs
+++ b/src/command/image_ship/edge_sharpen.rs
@@ -1,0 +1,97 @@
+use alloc::string::String;
+
+use crate::result::{Error, Result};
+
+const EDGE_SUFFIX: &str = "E";
+const EDGE_DEFAULT: u8 = 0;
+const EDGE_MAX: u8 = 24;
+
+/// Represents the image ship edge sharpen.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct EdgeSharpen {
+    strength: u8,
+}
+
+impl EdgeSharpen {
+    /// Creates a new [EdgeSharpen].
+    pub const fn new() -> Self {
+        Self {
+            strength: EDGE_DEFAULT,
+        }
+    }
+
+    /// Gets the [EdgeSharpen] strength setting.
+    pub const fn strength(&self) -> u8 {
+        self.strength
+    }
+
+    /// Creates a [EdgeSharpen] from a strength parameter.
+    pub const fn try_from_strength(strength: u8) -> Result<Self> {
+        match strength {
+            s if s <= EDGE_MAX => Ok(Self { strength }),
+            _ => Err(Error::InvalidValue(strength as usize)),
+        }
+    }
+
+    /// Gets the ASCII serial command code for [EdgeSharpen].
+    pub fn command(&self) -> String {
+        let strength = self.strength;
+        format!("{strength}{EDGE_SUFFIX}")
+    }
+}
+
+impl Default for EdgeSharpen {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<u8> for EdgeSharpen {
+    type Error = Error;
+
+    fn try_from(val: u8) -> Result<Self> {
+        Self::try_from_strength(val)
+    }
+}
+
+impl TryFrom<&str> for EdgeSharpen {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        let pos = val.find(EDGE_SUFFIX).ok_or(Error::InvalidVariant)?;
+        let exp_start = val[..pos]
+            .rfind(|c: char| c.is_ascii_uppercase() || c.is_ascii_lowercase())
+            .map(|s| s + 1)
+            .unwrap_or(0);
+
+        val[exp_start..pos]
+            .parse::<u8>()
+            .map_err(|_| Error::InvalidVariant)
+            .and_then(Self::try_from_strength)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        (0..=EDGE_MAX).for_each(|strength| {
+            let exp_strength = EdgeSharpen { strength };
+
+            assert_eq!(EdgeSharpen::try_from_strength(strength), Ok(exp_strength));
+            assert_eq!(exp_strength.strength(), strength);
+        });
+    }
+
+    #[test]
+    fn test_invalid() {
+        ((EDGE_MAX + 1)..=u8::MAX).for_each(|strength| {
+            let err = Error::InvalidValue(strength as usize);
+
+            assert_eq!(EdgeSharpen::try_from_strength(strength), Err(err));
+            assert_eq!(EdgeSharpen::try_from(strength), Err(err));
+        });
+    }
+}

--- a/src/command/image_ship/gamma_correction.rs
+++ b/src/command/image_ship/gamma_correction.rs
@@ -1,0 +1,97 @@
+use alloc::string::String;
+
+use crate::result::{Error, Result};
+
+const GAMMA_SUFFIX: &str = "K";
+const GAMMA_DEFAULT: u16 = 0;
+const GAMMA_MAX: u16 = 1000;
+
+/// Represents the image ship gamma correction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct GammaCorrection {
+    factor: u16,
+}
+
+impl GammaCorrection {
+    /// Creates a new [GammaCorrection].
+    pub const fn new() -> Self {
+        Self {
+            factor: GAMMA_DEFAULT,
+        }
+    }
+
+    /// Gets the [GammaCorrection] factor setting.
+    pub const fn factor(&self) -> u16 {
+        self.factor
+    }
+
+    /// Creates a [GammaCorrection] from a factor parameter.
+    pub const fn try_from_factor(factor: u16) -> Result<Self> {
+        match factor {
+            s if s <= GAMMA_MAX => Ok(Self { factor }),
+            _ => Err(Error::InvalidValue(factor as usize)),
+        }
+    }
+
+    /// Gets the ASCII serial command code for [GammaCorrection].
+    pub fn command(&self) -> String {
+        let factor = self.factor;
+        format!("{factor}{GAMMA_SUFFIX}")
+    }
+}
+
+impl Default for GammaCorrection {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<u16> for GammaCorrection {
+    type Error = Error;
+
+    fn try_from(val: u16) -> Result<Self> {
+        Self::try_from_factor(val)
+    }
+}
+
+impl TryFrom<&str> for GammaCorrection {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        let pos = val.find(GAMMA_SUFFIX).ok_or(Error::InvalidVariant)?;
+        let exp_start = val[..pos]
+            .rfind(|c: char| c.is_ascii_uppercase() || c.is_ascii_lowercase())
+            .map(|s| s + 1)
+            .unwrap_or(0);
+
+        val[exp_start..pos]
+            .parse::<u16>()
+            .map_err(|_| Error::InvalidVariant)
+            .and_then(Self::try_from_factor)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        (0..=GAMMA_MAX).for_each(|factor| {
+            let exp_factor = GammaCorrection { factor };
+
+            assert_eq!(GammaCorrection::try_from_factor(factor), Ok(exp_factor));
+            assert_eq!(exp_factor.factor(), factor);
+        });
+    }
+
+    #[test]
+    fn test_invalid() {
+        ((GAMMA_MAX + 1)..=u16::MAX).for_each(|factor| {
+            let err = Error::InvalidValue(factor as usize);
+
+            assert_eq!(GammaCorrection::try_from_factor(factor), Err(err));
+            assert_eq!(GammaCorrection::try_from(factor), Err(err));
+        });
+    }
+}

--- a/src/command/image_ship/histogram_ship.rs
+++ b/src/command/image_ship/histogram_ship.rs
@@ -1,0 +1,62 @@
+use crate::result::{Error, Result};
+
+const HISTO_NOSHIP: &str = "0W";
+const HISTO_SHIP: &str = "1W";
+
+/// Sets the image ship histogram ship.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HistogramShip {
+    /// Histogram don't ship.
+    Off,
+    /// Histogram ship.
+    On,
+}
+
+impl HistogramShip {
+    /// Creates a new [HistogramShip].
+    pub const fn new() -> Self {
+        Self::Off
+    }
+
+    /// Gets the ASCII serial command code for [HistogramShip].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Off => HISTO_NOSHIP,
+            Self::On => HISTO_SHIP,
+        }
+    }
+}
+
+impl Default for HistogramShip {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for HistogramShip {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(HISTO_NOSHIP) => Ok(Self::Off),
+            v if v.contains(HISTO_SHIP) => Ok(Self::On),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [HistogramShip::Off, HistogramShip::On]
+            .into_iter()
+            .zip([HISTO_NOSHIP, HISTO_SHIP])
+            .for_each(|(cmd, exp_ascii_cmd)| {
+                assert_eq!(cmd.command(), exp_ascii_cmd);
+                assert_eq!(HistogramShip::try_from(exp_ascii_cmd), Ok(cmd));
+            });
+    }
+}

--- a/src/command/image_ship/histogram_stretch.rs
+++ b/src/command/image_ship/histogram_stretch.rs
@@ -1,0 +1,62 @@
+use crate::result::{Error, Result};
+
+const HISTO_OFF: &str = "0H";
+const HISTO_ON: &str = "1H";
+
+/// Sets the image ship histogram stretch.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum HistogramStretch {
+    /// HistogramStretch disabled.
+    Off,
+    /// HistogramStretch enabled.
+    On,
+}
+
+impl HistogramStretch {
+    /// Creates a new [HistogramStretch].
+    pub const fn new() -> Self {
+        Self::Off
+    }
+
+    /// Gets the ASCII serial command code for [HistogramStretch].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Off => HISTO_OFF,
+            Self::On => HISTO_ON,
+        }
+    }
+}
+
+impl Default for HistogramStretch {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for HistogramStretch {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(HISTO_OFF) => Ok(Self::Off),
+            v if v.contains(HISTO_ON) => Ok(Self::On),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [HistogramStretch::Off, HistogramStretch::On]
+            .into_iter()
+            .zip([HISTO_OFF, HISTO_ON])
+            .for_each(|(cmd, exp_ascii_cmd)| {
+                assert_eq!(cmd.command(), exp_ascii_cmd);
+                assert_eq!(HistogramStretch::try_from(exp_ascii_cmd), Ok(cmd));
+            });
+    }
+}

--- a/src/command/image_ship/image_rotate.rs
+++ b/src/command/image_ship/image_rotate.rs
@@ -1,0 +1,77 @@
+use crate::result::{Error, Result};
+
+const ROTATE_0: &str = "0ir";
+const ROTATE_90: &str = "1ir";
+const ROTATE_180: &str = "2ir";
+const ROTATE_270: &str = "3ir";
+
+/// Sets the image ship image rotate.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ImageRotate {
+    /// Rotate 0 degrees (image snapped).
+    Degrees0,
+    /// Rotate 90 degrees to the right.
+    Degrees90,
+    /// Rotate 180 degrees.
+    Degrees180,
+    /// Rotate 270 degrees to the right (90 degrees left).
+    Degrees270,
+}
+
+impl ImageRotate {
+    /// Creates a new [ImageRotate].
+    pub const fn new() -> Self {
+        Self::Degrees0
+    }
+
+    /// Gets the ASCII serial command code for [ImageRotate].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Degrees0 => ROTATE_0,
+            Self::Degrees90 => ROTATE_90,
+            Self::Degrees180 => ROTATE_180,
+            Self::Degrees270 => ROTATE_270,
+        }
+    }
+}
+
+impl Default for ImageRotate {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for ImageRotate {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(ROTATE_0) => Ok(Self::Degrees0),
+            v if v.contains(ROTATE_90) => Ok(Self::Degrees90),
+            v if v.contains(ROTATE_180) => Ok(Self::Degrees180),
+            v if v.contains(ROTATE_270) => Ok(Self::Degrees270),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [
+            ImageRotate::Degrees0,
+            ImageRotate::Degrees90,
+            ImageRotate::Degrees180,
+            ImageRotate::Degrees270,
+        ]
+        .into_iter()
+        .zip([ROTATE_0, ROTATE_90, ROTATE_180, ROTATE_270])
+        .for_each(|(cmd, exp_ascii_cmd)| {
+            assert_eq!(cmd.command(), exp_ascii_cmd);
+            assert_eq!(ImageRotate::try_from(exp_ascii_cmd), Ok(cmd));
+        });
+    }
+}

--- a/src/command/image_ship/infinity_filter.rs
+++ b/src/command/image_ship/infinity_filter.rs
@@ -1,0 +1,62 @@
+use crate::result::{Error, Result};
+
+const FILTER_OFF: &str = "0A";
+const FILTER_ON: &str = "1A";
+
+/// Sets the image ship infinity filter.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InfinityFilter {
+    /// Infinity filter off.
+    Off,
+    /// Infinity filters on.
+    On,
+}
+
+impl InfinityFilter {
+    /// Creates a new [InfinityFilter].
+    pub const fn new() -> Self {
+        Self::Off
+    }
+
+    /// Gets the ASCII serial command code for [InfinityFilter].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Off => FILTER_OFF,
+            Self::On => FILTER_ON,
+        }
+    }
+}
+
+impl Default for InfinityFilter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for InfinityFilter {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(FILTER_OFF) => Ok(Self::Off),
+            v if v.contains(FILTER_ON) => Ok(Self::On),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [InfinityFilter::Off, InfinityFilter::On]
+            .into_iter()
+            .zip([FILTER_OFF, FILTER_ON])
+            .for_each(|(cmd, exp_ascii_cmd)| {
+                assert_eq!(cmd.command(), exp_ascii_cmd);
+                assert_eq!(InfinityFilter::try_from(exp_ascii_cmd), Ok(cmd));
+            });
+    }
+}

--- a/src/command/image_ship/invert_image.rs
+++ b/src/command/image_ship/invert_image.rs
@@ -1,0 +1,62 @@
+use crate::result::{Error, Result};
+
+const INVERT_X: &str = "1ix";
+const INVERT_Y: &str = "1iy";
+
+/// Sets the image ship invert image.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum InvertImage {
+    /// Invert around the X-axis.
+    X,
+    /// Invert around the Y-axis.
+    Y,
+}
+
+impl InvertImage {
+    /// Creates a new [InvertImage].
+    pub const fn new() -> Self {
+        Self::X
+    }
+
+    /// Gets the ASCII serial command code for [InvertImage].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::X => INVERT_X,
+            Self::Y => INVERT_Y,
+        }
+    }
+}
+
+impl Default for InvertImage {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for InvertImage {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(INVERT_X) => Ok(Self::X),
+            v if v.contains(INVERT_Y) => Ok(Self::Y),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [InvertImage::X, InvertImage::Y]
+            .into_iter()
+            .zip([INVERT_X, INVERT_Y])
+            .for_each(|(cmd, exp_ascii_cmd)| {
+                assert_eq!(cmd.command(), exp_ascii_cmd);
+                assert_eq!(InvertImage::try_from(exp_ascii_cmd), Ok(cmd));
+            });
+    }
+}

--- a/src/command/image_ship/jpeg_image_quality.rs
+++ b/src/command/image_ship/jpeg_image_quality.rs
@@ -1,0 +1,97 @@
+use alloc::string::String;
+
+use crate::result::{Error, Result};
+
+const JPEG_SUFFIX: &str = "J";
+const JPEG_DEFAULT: u8 = 50;
+const JPEG_MAX: u8 = 100;
+
+/// Represents the image ship JPEG image quality.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct JpegImageQuality {
+    quality: u8,
+}
+
+impl JpegImageQuality {
+    /// Creates a new [JpegImageQuality].
+    pub const fn new() -> Self {
+        Self {
+            quality: JPEG_DEFAULT,
+        }
+    }
+
+    /// Gets the [JpegImageQuality] quality setting.
+    pub const fn quality(&self) -> u8 {
+        self.quality
+    }
+
+    /// Creates a [JpegImageQuality] from a quality parameter.
+    pub const fn try_from_quality(quality: u8) -> Result<Self> {
+        match quality {
+            s if s <= JPEG_MAX => Ok(Self { quality }),
+            _ => Err(Error::InvalidValue(quality as usize)),
+        }
+    }
+
+    /// Gets the ASCII serial command code for [JpegImageQuality].
+    pub fn command(&self) -> String {
+        let quality = self.quality;
+        format!("{quality}{JPEG_SUFFIX}")
+    }
+}
+
+impl Default for JpegImageQuality {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<u8> for JpegImageQuality {
+    type Error = Error;
+
+    fn try_from(val: u8) -> Result<Self> {
+        Self::try_from_quality(val)
+    }
+}
+
+impl TryFrom<&str> for JpegImageQuality {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        let pos = val.find(JPEG_SUFFIX).ok_or(Error::InvalidVariant)?;
+        let exp_start = val[..pos]
+            .rfind(|c: char| c.is_ascii_uppercase() || c.is_ascii_lowercase())
+            .map(|s| s + 1)
+            .unwrap_or(0);
+
+        val[exp_start..pos]
+            .parse::<u8>()
+            .map_err(|_| Error::InvalidVariant)
+            .and_then(Self::try_from_quality)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        (0..=JPEG_MAX).for_each(|quality| {
+            let exp_quality = JpegImageQuality { quality };
+
+            assert_eq!(JpegImageQuality::try_from_quality(quality), Ok(exp_quality));
+            assert_eq!(exp_quality.quality(), quality);
+        });
+    }
+
+    #[test]
+    fn test_invalid() {
+        ((JPEG_MAX + 1)..=u8::MAX).for_each(|quality| {
+            let err = Error::InvalidValue(quality as usize);
+
+            assert_eq!(JpegImageQuality::try_from_quality(quality), Err(err));
+            assert_eq!(JpegImageQuality::try_from(quality), Err(err));
+        });
+    }
+}

--- a/src/command/image_ship/noise_reduction.rs
+++ b/src/command/image_ship/noise_reduction.rs
@@ -1,0 +1,62 @@
+use crate::result::{Error, Result};
+
+const NOISE_OFF: &str = "0if";
+const NOISE_ON: &str = "1if";
+
+/// Sets the image ship noise reduction.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum NoiseReduction {
+    /// Noise reduction off.
+    Off,
+    /// Salt and pepper noise reduction on.
+    On,
+}
+
+impl NoiseReduction {
+    /// Creates a new [NoiseReduction].
+    pub const fn new() -> Self {
+        Self::Off
+    }
+
+    /// Gets the ASCII serial command code for [NoiseReduction].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Off => NOISE_OFF,
+            Self::On => NOISE_ON,
+        }
+    }
+}
+
+impl Default for NoiseReduction {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for NoiseReduction {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(NOISE_OFF) => Ok(Self::Off),
+            v if v.contains(NOISE_ON) => Ok(Self::On),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [NoiseReduction::Off, NoiseReduction::On]
+            .into_iter()
+            .zip([NOISE_OFF, NOISE_ON])
+            .for_each(|(cmd, exp_ascii_cmd)| {
+                assert_eq!(cmd.command(), exp_ascii_cmd);
+                assert_eq!(NoiseReduction::try_from(exp_ascii_cmd), Ok(cmd));
+            });
+    }
+}

--- a/src/command/image_ship/pixel_depth.rs
+++ b/src/command/image_ship/pixel_depth.rs
@@ -1,0 +1,62 @@
+use crate::result::{Error, Result};
+
+const DEPTH_8BIT: &str = "8D";
+const DEPTH_1BIT: &str = "1D";
+
+/// Sets the image ship pixel depth.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PixelDepth {
+    /// 8 bits per pixel, grayscale.
+    Bit8,
+    /// 1 bit per pixel, black and white.
+    Bit1,
+}
+
+impl PixelDepth {
+    /// Creates a new [PixelDepth].
+    pub const fn new() -> Self {
+        Self::Bit8
+    }
+
+    /// Gets the ASCII serial command code for [PixelDepth].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Bit8 => DEPTH_8BIT,
+            Self::Bit1 => DEPTH_1BIT,
+        }
+    }
+}
+
+impl Default for PixelDepth {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for PixelDepth {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(DEPTH_8BIT) => Ok(Self::Bit8),
+            v if v.contains(DEPTH_1BIT) => Ok(Self::Bit1),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [PixelDepth::Bit8, PixelDepth::Bit1]
+            .into_iter()
+            .zip([DEPTH_8BIT, DEPTH_1BIT])
+            .for_each(|(cmd, exp_ascii_cmd)| {
+                assert_eq!(cmd.command(), exp_ascii_cmd);
+                assert_eq!(PixelDepth::try_from(exp_ascii_cmd), Ok(cmd));
+            });
+    }
+}

--- a/src/command/image_ship/pixel_ship.rs
+++ b/src/command/image_ship/pixel_ship.rs
@@ -1,0 +1,67 @@
+use crate::result::{Error, Result};
+
+const PIXEL_SHIP1: &str = "1S";
+const PIXEL_SHIP2: &str = "2S";
+const PIXEL_SHIP3: &str = "3S";
+
+/// Sets the image ship pixel ship.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PixelShip {
+    /// Pixel Ship skip 1 pixel evey 1 line.
+    Skip1,
+    /// Pixel Ship skip 2 pixel evey 2 line.
+    Skip2,
+    /// Pixel Ship skip 3 pixel evey 3 line.
+    Skip3,
+}
+
+impl PixelShip {
+    /// Creates a new [PixelShip].
+    pub const fn new() -> Self {
+        Self::Skip1
+    }
+
+    /// Gets the ASCII serial command code for [PixelShip].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Skip1 => PIXEL_SHIP1,
+            Self::Skip2 => PIXEL_SHIP2,
+            Self::Skip3 => PIXEL_SHIP3,
+        }
+    }
+}
+
+impl Default for PixelShip {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for PixelShip {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(PIXEL_SHIP1) => Ok(Self::Skip1),
+            v if v.contains(PIXEL_SHIP2) => Ok(Self::Skip2),
+            v if v.contains(PIXEL_SHIP3) => Ok(Self::Skip3),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [PixelShip::Skip1, PixelShip::Skip2, PixelShip::Skip3]
+            .into_iter()
+            .zip([PIXEL_SHIP1, PIXEL_SHIP2, PIXEL_SHIP3])
+            .for_each(|(cmd, exp_ascii_cmd)| {
+                assert_eq!(cmd.command(), exp_ascii_cmd);
+                assert_eq!(PixelShip::try_from(exp_ascii_cmd), Ok(cmd));
+            });
+    }
+}

--- a/src/command/image_ship/protocol.rs
+++ b/src/command/image_ship/protocol.rs
@@ -1,0 +1,82 @@
+use crate::result::{Error, Result};
+
+const PROTOCOL_RAW: &str = "0P";
+const PROTOCOL_USB: &str = "2P";
+const PROTOCOL_HMODEM_COMP: &str = "3P";
+const PROTOCOL_HMODEM: &str = "4P";
+
+/// Sets the image ship protocol.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Protocol {
+    /// Protocol none, raw data.
+    Raw,
+    /// Protocol none, USB default.
+    Usb,
+    /// Protocol HMODEM compressed, RS232 default.
+    HmodemCompressed,
+    /// Protocol HMODEM.
+    Hmodem,
+}
+
+impl Protocol {
+    /// Creates a new [Protocol].
+    pub const fn new() -> Self {
+        Self::Raw
+    }
+
+    /// Gets the ASCII serial command code for [Protocol].
+    pub const fn command(&self) -> &str {
+        match self {
+            Self::Raw => PROTOCOL_RAW,
+            Self::Usb => PROTOCOL_USB,
+            Self::HmodemCompressed => PROTOCOL_HMODEM_COMP,
+            Self::Hmodem => PROTOCOL_HMODEM,
+        }
+    }
+}
+
+impl Default for Protocol {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TryFrom<&str> for Protocol {
+    type Error = Error;
+
+    fn try_from(val: &str) -> Result<Self> {
+        match val {
+            v if v.contains(PROTOCOL_RAW) => Ok(Self::Raw),
+            v if v.contains(PROTOCOL_USB) => Ok(Self::Usb),
+            v if v.contains(PROTOCOL_HMODEM_COMP) => Ok(Self::HmodemCompressed),
+            v if v.contains(PROTOCOL_HMODEM) => Ok(Self::Hmodem),
+            _ => Err(Error::InvalidVariant),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid() {
+        [
+            Protocol::Raw,
+            Protocol::Usb,
+            Protocol::HmodemCompressed,
+            Protocol::Hmodem,
+        ]
+        .into_iter()
+        .zip([
+            PROTOCOL_RAW,
+            PROTOCOL_USB,
+            PROTOCOL_HMODEM_COMP,
+            PROTOCOL_HMODEM,
+        ])
+        .for_each(|(cmd, exp_ascii_cmd)| {
+            assert_eq!(cmd.command(), exp_ascii_cmd);
+            assert_eq!(Protocol::try_from(exp_ascii_cmd), Ok(cmd));
+        });
+    }
+}

--- a/src/command/image_snap.rs
+++ b/src/command/image_snap.rs
@@ -3,6 +3,7 @@
 use alloc::string::{String, ToString};
 
 use crate::result::{Error, Result};
+use crate::modifier_field;
 
 mod beeper;
 mod delta_for_acceptance;
@@ -43,39 +44,165 @@ pub struct ImageSnap {
     target_set_point: Option<TargetSetPoint>,
 }
 
-macro_rules! image_snap_field {
-    ($field:ident: $field_ty:ty) => {
-        paste::paste! {
-            impl ImageSnap {
-                #[doc = "Gets the [" $field_ty "] for [ImageSnap]."]
-                pub const fn $field(&self) -> Option<$field_ty> {
-                    self.$field
-                }
-
-                #[doc = "Sets the [" $field_ty "] for [ImageSnap]."]
-                pub fn [<set_ $field>](&mut self, val: $field_ty) {
-                    self.$field = Some(val);
-                }
-
-                #[doc = "Unsets the [" $field_ty "] for [ImageSnap]."]
-                pub fn [<unset_ $field>](&mut self) {
-                    self.$field = None;
-                }
-            }
-        }
-    };
+modifier_field! {
+    ImageSnap,
+    imaging_style: ImagingStyle,
+    [
+        beeper,
+        wait_for_trigger,
+        led,
+        exposure,
+        gain,
+        target_white_value,
+        delta_for_acceptance,
+        update_tries,
+        target_set_point,
+    ],
 }
 
-image_snap_field!(imaging_style: ImagingStyle);
-image_snap_field!(beeper: Beeper);
-image_snap_field!(wait_for_trigger: WaitForTrigger);
-image_snap_field!(led: LED);
-image_snap_field!(exposure: Exposure);
-image_snap_field!(gain: Gain);
-image_snap_field!(target_white_value: TargetWhiteValue);
-image_snap_field!(delta_for_acceptance: DeltaForAcceptance);
-image_snap_field!(update_tries: UpdateTries);
-image_snap_field!(target_set_point: TargetSetPoint);
+modifier_field! {
+    ImageSnap,
+    beeper: Beeper,
+    [
+        imaging_style,
+        wait_for_trigger,
+        led,
+        exposure,
+        gain,
+        target_white_value,
+        delta_for_acceptance,
+        update_tries,
+        target_set_point,
+    ],
+}
+
+modifier_field! {
+    ImageSnap,
+    wait_for_trigger: WaitForTrigger,
+    [
+        imaging_style,
+        beeper,
+        led,
+        exposure,
+        gain,
+        target_white_value,
+        delta_for_acceptance,
+        update_tries,
+        target_set_point,
+    ],
+}
+
+modifier_field! {
+    ImageSnap,
+    led: LED,
+    [
+        imaging_style,
+        beeper,
+        wait_for_trigger,
+        exposure,
+        gain,
+        target_white_value,
+        delta_for_acceptance,
+        update_tries,
+        target_set_point,
+    ],
+}
+
+modifier_field! {
+    ImageSnap,
+    exposure: Exposure,
+    [
+        imaging_style,
+        beeper,
+        wait_for_trigger,
+        led,
+        gain,
+        target_white_value,
+        delta_for_acceptance,
+        update_tries,
+        target_set_point,
+    ],
+}
+
+modifier_field! {
+    ImageSnap,
+    gain: Gain,
+    [
+        imaging_style,
+        beeper,
+        wait_for_trigger,
+        led,
+        exposure,
+        target_white_value,
+        delta_for_acceptance,
+        update_tries,
+        target_set_point,
+    ],
+}
+
+modifier_field! {
+    ImageSnap,
+    target_white_value: TargetWhiteValue,
+    [
+        imaging_style,
+        beeper,
+        wait_for_trigger,
+        led,
+        exposure,
+        gain,
+        delta_for_acceptance,
+        update_tries,
+        target_set_point,
+    ],
+}
+
+modifier_field! {
+    ImageSnap,
+    delta_for_acceptance: DeltaForAcceptance,
+    [
+        imaging_style,
+        beeper,
+        wait_for_trigger,
+        led,
+        exposure,
+        gain,
+        target_white_value,
+        update_tries,
+        target_set_point,
+    ],
+}
+
+modifier_field! {
+    ImageSnap,
+    update_tries: UpdateTries,
+    [
+        imaging_style,
+        beeper,
+        wait_for_trigger,
+        led,
+        exposure,
+        gain,
+        target_white_value,
+        delta_for_acceptance,
+        target_set_point,
+    ],
+}
+
+modifier_field! {
+    ImageSnap,
+    target_set_point: TargetSetPoint,
+    [
+        imaging_style,
+        beeper,
+        wait_for_trigger,
+        led,
+        exposure,
+        gain,
+        target_white_value,
+        delta_for_acceptance,
+        update_tries,
+    ],
+}
 
 impl ImageSnap {
     /// Creates a new [ImageSnap].
@@ -91,166 +218,6 @@ impl ImageSnap {
             delta_for_acceptance: None,
             update_tries: None,
             target_set_point: None,
-        }
-    }
-
-    /// Builder function that sets the [ImagingStyle].
-    pub const fn with_imaging_style(self, val: ImagingStyle) -> Self {
-        Self {
-            imaging_style: Some(val),
-            beeper: self.beeper,
-            wait_for_trigger: self.wait_for_trigger,
-            led: self.led,
-            exposure: self.exposure,
-            gain: self.gain,
-            target_white_value: self.target_white_value,
-            delta_for_acceptance: self.delta_for_acceptance,
-            update_tries: self.update_tries,
-            target_set_point: self.target_set_point,
-        }
-    }
-
-    /// Builder function that sets the [Beeper].
-    pub const fn with_beeper(self, val: Beeper) -> Self {
-        Self {
-            imaging_style: self.imaging_style,
-            beeper: Some(val),
-            wait_for_trigger: self.wait_for_trigger,
-            led: self.led,
-            exposure: self.exposure,
-            gain: self.gain,
-            target_white_value: self.target_white_value,
-            delta_for_acceptance: self.delta_for_acceptance,
-            update_tries: self.update_tries,
-            target_set_point: self.target_set_point,
-        }
-    }
-
-    /// Builder function that sets the [WaitForTrigger].
-    pub const fn with_wait_for_trigger(self, val: WaitForTrigger) -> Self {
-        Self {
-            imaging_style: self.imaging_style,
-            beeper: self.beeper,
-            wait_for_trigger: Some(val),
-            led: self.led,
-            exposure: self.exposure,
-            gain: self.gain,
-            target_white_value: self.target_white_value,
-            delta_for_acceptance: self.delta_for_acceptance,
-            update_tries: self.update_tries,
-            target_set_point: self.target_set_point,
-        }
-    }
-
-    /// Builder function that sets the [LED].
-    pub const fn with_led(self, val: LED) -> Self {
-        Self {
-            imaging_style: self.imaging_style,
-            beeper: self.beeper,
-            wait_for_trigger: self.wait_for_trigger,
-            led: Some(val),
-            exposure: self.exposure,
-            gain: self.gain,
-            target_white_value: self.target_white_value,
-            delta_for_acceptance: self.delta_for_acceptance,
-            update_tries: self.update_tries,
-            target_set_point: self.target_set_point,
-        }
-    }
-
-    /// Builder function that sets the [Exposure].
-    pub const fn with_exposure(self, val: Exposure) -> Self {
-        Self {
-            imaging_style: self.imaging_style,
-            beeper: self.beeper,
-            wait_for_trigger: self.wait_for_trigger,
-            led: self.led,
-            exposure: Some(val),
-            gain: self.gain,
-            target_white_value: self.target_white_value,
-            delta_for_acceptance: self.delta_for_acceptance,
-            update_tries: self.update_tries,
-            target_set_point: self.target_set_point,
-        }
-    }
-
-    /// Builder function that sets the [Gain].
-    pub const fn with_gain(self, val: Gain) -> Self {
-        Self {
-            imaging_style: self.imaging_style,
-            beeper: self.beeper,
-            wait_for_trigger: self.wait_for_trigger,
-            led: self.led,
-            exposure: self.exposure,
-            gain: Some(val),
-            target_white_value: self.target_white_value,
-            delta_for_acceptance: self.delta_for_acceptance,
-            update_tries: self.update_tries,
-            target_set_point: self.target_set_point,
-        }
-    }
-
-    /// Builder function that sets the [TargetWhiteValue].
-    pub const fn with_target_white_value(self, val: TargetWhiteValue) -> Self {
-        Self {
-            imaging_style: self.imaging_style,
-            beeper: self.beeper,
-            wait_for_trigger: self.wait_for_trigger,
-            led: self.led,
-            exposure: self.exposure,
-            gain: self.gain,
-            target_white_value: Some(val),
-            delta_for_acceptance: self.delta_for_acceptance,
-            update_tries: self.update_tries,
-            target_set_point: self.target_set_point,
-        }
-    }
-
-    /// Builder function that sets the [DeltaForAcceptance].
-    pub const fn with_delta_for_acceptance(self, val: DeltaForAcceptance) -> Self {
-        Self {
-            imaging_style: self.imaging_style,
-            beeper: self.beeper,
-            wait_for_trigger: self.wait_for_trigger,
-            led: self.led,
-            exposure: self.exposure,
-            gain: self.gain,
-            target_white_value: self.target_white_value,
-            delta_for_acceptance: Some(val),
-            update_tries: self.update_tries,
-            target_set_point: self.target_set_point,
-        }
-    }
-
-    /// Builder function that sets the [UpdateTries].
-    pub const fn with_update_tries(self, val: UpdateTries) -> Self {
-        Self {
-            imaging_style: self.imaging_style,
-            beeper: self.beeper,
-            wait_for_trigger: self.wait_for_trigger,
-            led: self.led,
-            exposure: self.exposure,
-            gain: self.gain,
-            target_white_value: self.target_white_value,
-            delta_for_acceptance: self.delta_for_acceptance,
-            update_tries: Some(val),
-            target_set_point: self.target_set_point,
-        }
-    }
-
-    /// Builder function that sets the [TargetSetPoint].
-    pub const fn with_target_set_point(self, val: TargetSetPoint) -> Self {
-        Self {
-            imaging_style: self.imaging_style,
-            beeper: self.beeper,
-            wait_for_trigger: self.wait_for_trigger,
-            led: self.led,
-            exposure: self.exposure,
-            gain: self.gain,
-            target_white_value: self.target_white_value,
-            delta_for_acceptance: self.delta_for_acceptance,
-            update_tries: self.update_tries,
-            target_set_point: Some(val),
         }
     }
 

--- a/src/command/image_snap.rs
+++ b/src/command/image_snap.rs
@@ -1,9 +1,6 @@
 //! Types and algorithms related to `Image Snap` configuration.
 
-use alloc::string::{String, ToString};
-
-use crate::result::{Error, Result};
-use crate::modifier_field;
+use crate::{modifier_command, modifier_field};
 
 mod beeper;
 mod delta_for_acceptance;
@@ -27,21 +24,20 @@ pub use target_white_value::*;
 pub use update_tries::*;
 pub use wait_for_trigger::*;
 
-const IMAGE_SNAP: &str = "IMGSNP";
-
-/// Configure all barcode `Image Snap` encodings.
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub struct ImageSnap {
-    imaging_style: Option<ImagingStyle>,
-    beeper: Option<Beeper>,
-    wait_for_trigger: Option<WaitForTrigger>,
-    led: Option<LED>,
-    exposure: Option<Exposure>,
-    gain: Option<Gain>,
-    target_white_value: Option<TargetWhiteValue>,
-    delta_for_acceptance: Option<DeltaForAcceptance>,
-    update_tries: Option<UpdateTries>,
-    target_set_point: Option<TargetSetPoint>,
+modifier_command! {
+    /// Configure all barcode `Image Snap` encodings.
+    ImageSnap: "IMGSNP" {
+        imaging_style: ImagingStyle,
+        beeper: Beeper,
+        wait_for_trigger: WaitForTrigger,
+        led: LED,
+        exposure: Exposure,
+        gain: Gain,
+        target_white_value: TargetWhiteValue,
+        delta_for_acceptance: DeltaForAcceptance,
+        update_tries: UpdateTries,
+        target_set_point: TargetSetPoint,
+    }
 }
 
 modifier_field! {
@@ -204,116 +200,6 @@ modifier_field! {
     ],
 }
 
-impl ImageSnap {
-    /// Creates a new [ImageSnap].
-    pub const fn new() -> Self {
-        Self {
-            imaging_style: None,
-            beeper: None,
-            wait_for_trigger: None,
-            led: None,
-            exposure: None,
-            gain: None,
-            target_white_value: None,
-            delta_for_acceptance: None,
-            update_tries: None,
-            target_set_point: None,
-        }
-    }
-
-    /// Gets the ASCII serial command code for [ImageSnap].
-    pub fn command(&self) -> String {
-        let imaging = self
-            .imaging_style
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let beeper = self
-            .beeper
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let wait_for_trigger = self
-            .wait_for_trigger
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let led = self
-            .led
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let exposure = self
-            .exposure
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let gain = self
-            .gain
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let twv = self
-            .target_white_value
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let delta = self
-            .delta_for_acceptance
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let update = self
-            .update_tries
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        let tsp = self
-            .target_set_point
-            .map(|v| v.command().to_string())
-            .unwrap_or_default();
-
-        format!("{IMAGE_SNAP}{imaging}{beeper}{wait_for_trigger}{led}{exposure}{gain}{twv}{delta}{update}{tsp}")
-    }
-}
-
-impl Default for ImageSnap {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl TryFrom<&str> for ImageSnap {
-    type Error = Error;
-
-    fn try_from(val: &str) -> Result<Self> {
-        let rem = val.strip_prefix(IMAGE_SNAP).ok_or(Error::InvalidVariant)?;
-        let imaging_style = ImagingStyle::try_from(rem).ok();
-        let beeper = Beeper::try_from(rem).ok();
-        let wait_for_trigger = WaitForTrigger::try_from(rem).ok();
-        let led = LED::try_from(rem).ok();
-        let exposure = Exposure::try_from(rem).ok();
-        let gain = Gain::try_from(rem).ok();
-        let target_white_value = TargetWhiteValue::try_from(rem).ok();
-        let delta_for_acceptance = DeltaForAcceptance::try_from(rem).ok();
-        let update_tries = UpdateTries::try_from(rem).ok();
-        let target_set_point = TargetSetPoint::try_from(rem).ok();
-
-        Ok(Self {
-            imaging_style,
-            beeper,
-            wait_for_trigger,
-            led,
-            exposure,
-            gain,
-            target_white_value,
-            delta_for_acceptance,
-            update_tries,
-            target_set_point,
-        })
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -344,6 +230,7 @@ mod tests {
         let exp_delta_for_acceptance = DeltaForAcceptance::new();
         let exp_update_tries = UpdateTries::new();
         let exp_target_set_point = TargetSetPoint::new();
+        let prefix = ImageSnap::prefix();
 
         [
             "",
@@ -360,7 +247,7 @@ mod tests {
             "1P0B0T0L7874E1G125W25D6U50%",
         ]
         .into_iter()
-        .map(|s| format!("{IMAGE_SNAP}{s}"))
+        .map(|s| format!("{prefix}{s}"))
         .zip([
             ImageSnap::new(),
             ImageSnap::new().with_imaging_style(exp_imaging_style),

--- a/src/command/macros.rs
+++ b/src/command/macros.rs
@@ -1,0 +1,32 @@
+/// Helper macro to define command modifier field access.
+#[macro_export]
+macro_rules! modifier_field {
+    ($cmd:ident, $field:ident: $field_ty:ty, [$($not_field:ident$(,)?)+]$(,)?) => {
+        paste::paste! {
+            impl $cmd {
+                #[doc = "Gets the [" $field_ty "] for [" $cmd "]."]
+                pub const fn $field(&self) -> Option<$field_ty> {
+                    self.$field
+                }
+
+                #[doc = "Sets the [" $field_ty "] for [" $cmd "]."]
+                pub fn [<set_ $field>](&mut self, val: $field_ty) {
+                    self.$field = Some(val);
+                }
+
+                #[doc = "Unsets the [" $field_ty "] for [" $cmd "]."]
+                pub fn [<unset_ $field>](&mut self) {
+                    self.$field = None;
+                }
+
+                #[doc = "Builder function that sets the [" $field_ty "] for [" $cmd "]."]
+                pub const fn [<with_ $field>](self, val: $field_ty) -> Self {
+                    Self {
+                        $field: Some(val),
+                        $($not_field: self.$not_field,)+
+                    }
+                }
+            }
+        }
+    };
+}

--- a/src/command/macros.rs
+++ b/src/command/macros.rs
@@ -1,3 +1,65 @@
+#[macro_export]
+macro_rules! modifier_command {
+    (
+        $(#[$doc:meta])+
+        $cmd:ident: $prefix:literal { $($field:ident: $field_ty:ident$(,)?)+ }$(,)?) => {
+        paste::paste! {
+            $(#[$doc])+
+            #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+            pub struct $cmd {
+                $($field: Option<$field_ty>,)+
+            }
+
+            impl $cmd {
+                #[doc = "Creates a new [" $cmd "]."]
+                pub const fn new() -> Self {
+                    Self {
+                        $($field: None,)+
+                    }
+                }
+
+                #[doc = "Gets the ASCII serial command code for [" $cmd "]."]
+                pub fn command(&self) -> alloc::string::String {
+                    format!("{self}")
+                }
+
+                #[doc = "Gets the command ASCII prefix for [" $cmd "]."]
+                pub const fn prefix() -> &'static str {
+                    $prefix
+                }
+            }
+
+            impl Default for $cmd {
+                fn default() -> Self {
+                    Self::new()
+                }
+            }
+
+            impl TryFrom<&str> for $cmd {
+                type Error = $crate::result::Error;
+
+                fn try_from(val: &str) -> $crate::result::Result<Self> {
+                    let rem = val.strip_prefix($prefix).ok_or($crate::result::Error::InvalidVariant)?;
+
+                    Ok(Self {
+                        $($field: $field_ty::try_from(rem).ok(),)+
+                    })
+                }
+            }
+
+            impl core::fmt::Display for $cmd {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    write!(f, "{}", $prefix)?;
+                    $(
+                        write!(f, "{}", self.$field.map(|c| alloc::string::String::from(c.command())).unwrap_or_default())?;
+                    )+
+                    Ok(())
+                }
+            }
+        }
+    }
+}
+
 /// Helper macro to define command modifier field access.
 #[macro_export]
 macro_rules! modifier_field {


### PR DESCRIPTION
Adds implementations for the `ImageShip` command, and all modifier fields.

Adds helper macro definitions to reduce boilerplate.