### PR TITLE
version: bump to 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vuquest-3320"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 authors = ["Vuquest 3320 developers", "Decapod ATM developers"]
 description = "Serial communication protocol for Honeywell BCS devices"
@@ -17,11 +17,12 @@ version = "0.4"
 default-features = false
 
 [dependencies.serialport]
-version = "4.2"
+version = "4.6"
 default-features = false
+optional = true
 
 [dependencies.paste]
 version = "1.0"
 
 [features]
-std = []
+std = ["serialport"]


### PR DESCRIPTION
Bumps the minor release version to `v0.2.0` for additional command types.